### PR TITLE
chore(build): add gh actions trigger to codebuild

### DIFF
--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Post results
         uses: slackapi/slack-github-action@v1.14.0
         with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\"}"
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"https://d2irdh6zupqygx.cloudfront.net/${{steps.codebuild.outputs.aws-build-id}}/ot3-oe/opentron/toradex-minimal.tar\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -2,6 +2,8 @@ name: 'Build OT3 image'
 
 on:
   push:
+    branches:
+      - '*'
     tags-ignore:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -1,0 +1,31 @@
+name: 'Build OT3 image'
+
+on:
+  push:
+    tags-ignore:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  invoke-build:
+    name: 'invoking codebuild build'
+    timeout-minutes: 480
+    runs-on: 'ubuntu-18.04'
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Run CodeBuild
+        id: codebuild
+        uses: aws-actions/aws-codebuild-run-build@v1.0.3
+        with:
+          project-name: ${{ secrets.AWS_CODEBUILD_PROJECT_NAME }}
+      - name: Post results
+        uses: slackapi/slack-github-action@v1.14.0
+        with:
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,9 +13,6 @@ phases:
     commands:
       - echo ${CODEBUILD_SRC_DIR}
       - docker run --mount type=bind,src=${CODEBUILD_SRC_DIR},dst=/volumes/oe-core,consistency=delegated ot3-image:latest
-cache:
-  paths:
-    - downloads/**/*
 artifacts:
   base-directory: build/deploy
   files:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,10 +13,6 @@ phases:
     commands:
       - echo ${CODEBUILD_SRC_DIR}
       - docker run --mount type=bind,src=${CODEBUILD_SRC_DIR},dst=/volumes/oe-core,consistency=delegated ot3-image:latest
-  post_build:
-    commands:
-      - mkdir -p build/deploy/opentrons
-      - D=build/deploy/images/verdin-imx8mm/ cp ${D}/$(find ${D} | grep Reference-Image-Minimal-Tezi | head -n 1) build/deploy/opentrons/toradex-minimal.tar
 cache:
   paths:
     - downloads/**/*

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,9 +13,16 @@ phases:
     commands:
       - echo ${CODEBUILD_SRC_DIR}
       - docker run --mount type=bind,src=${CODEBUILD_SRC_DIR},dst=/volumes/oe-core,consistency=delegated ot3-image:latest
-
+  post_build:
+    commands:
+      - mkdir -p build/deploy/opentrons
+      - D=build/deploy/images/verdin-imx8mm/ cp ${D}/$(find ${D} | grep Reference-Image-Minimal-Tezi | head -n 1) build/deploy/opentrons/toradex-minimal.tar
+cache:
+  paths:
+    - downloads/**/*
 artifacts:
   base-directory: build/deploy
   files:
-    - '**/*'
+    - 'opentrons/*'
+    - 'images/**/*'
   enable-symlinks: 'yes'

--- a/start.sh
+++ b/start.sh
@@ -20,4 +20,4 @@ BB_NUMBER_THREADS=$((`nproc`-1)) bitbake tdx-reference-minimal-image
 
 cd ${THISDIR}
 mkdir -p build/deploy/opentrons
-cp $(find build/deploy/verdin-imx8mm/ | grep Reference-Minimal-Image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar
+cp $(find build/deploy/images/verdin-imx8mm/ | grep Reference-Minimal-Image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar

--- a/start.sh
+++ b/start.sh
@@ -17,3 +17,7 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 . layers/openembedded-core/oe-init-build-env ${THISDIR}/build
 
 BB_NUMBER_THREADS=$((`nproc`-1)) bitbake tdx-reference-minimal-image
+
+cd ${THISDIR}
+mkdir -p build/deploy/opentrons
+cp $(find build/deploy/verdin-imx8mm/ | grep Toradex-Minimal-Image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar

--- a/start.sh
+++ b/start.sh
@@ -20,4 +20,4 @@ BB_NUMBER_THREADS=$((`nproc`-1)) bitbake tdx-reference-minimal-image
 
 cd ${THISDIR}
 mkdir -p build/deploy/opentrons
-cp $(find build/deploy/verdin-imx8mm/ | grep Toradex-Minimal-Image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar
+cp $(find build/deploy/verdin-imx8mm/ | grep Reference-Minimal-Image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar


### PR DESCRIPTION
To avoid having to set up aws webhooks, we can try triggering the codebuild with [this aws-maintained action](https://github.com/aws-actions/aws-codebuild-run-build) and posting the result in slack.