### PR TITLE
chore: meta-opentrons: branch main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
 [submodule "layers/meta-opentrons"]
 	path = layers/meta-opentrons
 	url = https://github.com/Opentrons/meta-opentrons.git
-	branch = opentrons-recipe
+	branch = main
 [submodule "tools/bitbake"]
 	path = tools/bitbake
 	url = https://github.com/openembedded/bitbake.git


### PR DESCRIPTION
We used to have main of this repo pulling opentrons-recipe of the
opentrons metalayer, but now that's merged it can (and needs to be) main.