### PR TITLE
fix(start.sh bblayers.conf): copy wic image at end of build. make met…

### DIFF
--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -43,15 +43,6 @@ jobs:
       - name: Post results
         uses: slackapi/slack-github-action@v1.14.0
         with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\"}"
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\" \"partitionImage\":\"${{steps.result-wic-gz.outputs.wic-gz-url}}\" \"partitionImageBmap\":\"${{steps.result-wic-bmap.outputs.wic-bmap-url}}\"}"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - name: Post WIC bmap
-        uses: slackapi/slack-github-action@v1.14.0
-        with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-wic-bamp.outputs.wic-bmap-url}}\"}"
-      - name: Post WIC gz 
-        uses: slackapi/slack-github-action@v1.14.0
-        with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-wic-gz.outputs.wic-gz-url}}\"}"
 

--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -30,9 +30,13 @@ jobs:
         run: |
           buildid=$(echo '${{ steps.codebuild.outputs.aws-build-id }}' | cut -d: -f2-)
           echo "::set-output name=url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-image.tar"
+	  echo "::set-output name=wic-gz-url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-ot3-image-verdin-imx8mm.wic.gz" 
+	  echo "::set-output name=wic-bmap-url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-ot3-image-verdin-imx8mm.wic.bmap" 
       - name: Post results
         uses: slackapi/slack-github-action@v1.14.0
         with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\"}"
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\" 
+		   \"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.wiz-gz-url}}\" 
+\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.output.wic-bmap-url}}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -30,13 +30,28 @@ jobs:
         run: |
           buildid=$(echo '${{ steps.codebuild.outputs.aws-build-id }}' | cut -d: -f2-)
           echo "::set-output name=url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-image.tar"
-	  echo "::set-output name=wic-gz-url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-ot3-image-verdin-imx8mm.wic.gz" 
-	  echo "::set-output name=wic-bmap-url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-ot3-image-verdin-imx8mm.wic.bmap" 
+      - name: Build WIC bmap
+        id: result-wic-bmap
+        run: |
+          buildid=$(echo '${{ steps.codebuild.outputs.aws-build-id }}' | cut -d: -f2-)
+          echo "::set-output name=wic-bmap-url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-ot3-image-verdin-imx8mm.wic.bmap"
+      - name: Build WIC gz 
+        id: result-wic-gz
+        run: |
+         buildid=$(echo '${{ steps.codebuild.outputs.aws-build-id }}' | cut -d: -f2-)
+         echo "::set-output name=wic-gz-url::https://d2irdh6zupqygx.cloudfront.net/${buildid}/ot3-oe/opentrons/opentrons-ot3-image-verdin-imx8mm.wic.gz"
       - name: Post results
         uses: slackapi/slack-github-action@v1.14.0
         with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\" 
-		   \"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.wiz-gz-url}}\" 
-\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.output.wic-bmap-url}}\"}"
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Post WIC bmap
+        uses: slackapi/slack-github-action@v1.14.0
+        with:
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-wic-bamp.outputs.wic-bmap-url}}\"}"
+      - name: Post WIC gz 
+        uses: slackapi/slack-github-action@v1.14.0
+        with:
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-wic-gz.outputs.wic-gz-url}}\"}"
+

--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Post results
         uses: slackapi/slack-github-action@v1.14.0
         with:
-          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\" \"partitionImage\":\"${{steps.result-wic-gz.outputs.wic-gz-url}}\" \"partitionImageBmap\":\"${{steps.result-wic-bmap.outputs.wic-bmap-url}}\"}"
+          payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\", \"partitionImage\":\"${{steps.result-wic-gz.outputs.wic-gz-url}}\", \"partitionImageBmap\":\"${{steps.result-wic-bmap.outputs.wic-bmap-url}}\"}"
         env:
 

--- a/.github/workflows/build-ot3.yml
+++ b/.github/workflows/build-ot3.yml
@@ -45,4 +45,5 @@ jobs:
         with:
           payload: "{\"s3-url\":\"https://s3.console.aws.amazon.com/s3/buckets/ot3-builds?prefix=${{ steps.codebuild.outputs.aws-build-id }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"image\":\"${{steps.result-url.outputs.url}}\", \"partitionImage\":\"${{steps.result-wic-gz.outputs.wic-gz-url}}\", \"partitionImageBmap\":\"${{steps.result-wic-bmap.outputs.wic-bmap-url}}\"}"
         env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -6,6 +6,7 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
+  ${TOPDIR}/../layers/meta-opentrons \
   ${TOPDIR}/../layers/meta-toradex-nxp \
   ${TOPDIR}/../layers/meta-freescale \
   ${TOPDIR}/../layers/meta-freescale-3rdparty \
@@ -26,5 +27,4 @@ BBLAYERS ?= " \
   ${TOPDIR}/../layers/meta-toradex-distro \
   ${TOPDIR}/../layers/meta-yocto/meta-poky \
   ${TOPDIR}/../layers/openembedded-core/meta \
-  ${TOPDIR}/../layers/meta-opentrons \
   "

--- a/start.sh
+++ b/start.sh
@@ -16,8 +16,11 @@ patch ./layers/meta-toradex-nxp/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bb 
 export BITBAKEDIR=${THISDIR}/tools/bitbake
 . layers/openembedded-core/oe-init-build-env ${THISDIR}/build
 
-BB_NUMBER_THREADS=$((`nproc`-1)) bitbake tdx-reference-minimal-image
+BB_NUMBER_THREADS=$((`nproc`-1)) bitbake opentrons-ot3-image 
 
 cd ${THISDIR}
 mkdir -p build/deploy/opentrons
-cp $(find build/deploy/images/verdin-imx8mm/ | grep Reference-Minimal-Image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar
+cp $(find build/deploy/images/verdin-imx8mm/ | grep opentrons-ot3-image-Tezi | head -n 1) build/deploy/opentrons/opentrons-image.tar
+find . -name opentrons-ot3-image-verdin-imx8mm.wic.bmap -exec cp {} build/deploy/opentrons \;
+find . -name opentrons-ot3-image-verdin-imx8mm.wic.gz -exec cp {} build/deploy/opentrons \;
+


### PR DESCRIPTION
oe-core changes
Make meta-opentrons priority the highest. There are some machine definitions with the same names in meta-opentrons and other meta-layers coming in from the bsp. While we're still hanging on to some of the bsp provided classes, meta-layers, etc, we can make the priority for meta-opentrons the highest (by just moving it up in the bblayers.conf list). 

Image with A/B partitions is a wic image, copying that over from the container after build completes. 