### PR TITLE
chore(build): slight build speedups, more capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ENV USER_NAME opentrons-ci
-ENV PROJECT ot3
+
 
 # The running container writes all the build artifacts to a host directory (outside the container).
 # The container can only write files to host directories, if it uses the same user ID and
@@ -35,6 +34,9 @@ ENV PROJECT ot3
 # name of the group and user is ot3.
 ARG host_uid=1001
 ARG host_gid=1001
+ARG username=opentrons-ci
+ENV USER_NAME ${username}
+ENV PROJECT ot3
 RUN groupadd -g $host_gid $USER_NAME || true \
     && useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER_NAME || true \
     && usermod -aG sudo $USER_NAME \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,9 @@ RUN git config --global user.name "Opentrons" && \
 # levels must be the same as on the host.
 ENV BUILD_INPUT_DIR /volumes/oe-core
 ENV BUILD_OUTPUT_DIR ${BUILD_INPUT_DIR}/build
+COPY start.sh /start.sh
+RUN sudo chown $USER_NAME:$USER_NAME /start.sh && chmod ug+rwx /start.sh
 
 WORKDIR $BUILD_INPUT_DIR
 
-CMD sudo chown -hR $USER_NAME:$USER_NAME /volumes && chmod -R ug+rw /volumes && ${BUILD_INPUT_DIR}/start.sh
+ENTRYPOINT ["/start.sh", "/volumes/oe-core"]

--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ To change what a recipe checks out, cd into that recipe and change the branch or
 
 Do not try to build this on anything other than a linux machine that is extremely beefy. It requires docker, which will make it incredibly slow on osx, and uses bind mounts, which will make it incredibly incredibly slow on osx, and it uses bash and default paths outside the container, which will make it not work on windows. Try and use something that has like 6C/12T and at least 32GiB RAM. Or rely on the automated builds.
 
-Once you have all that, you should be able to run `./ot3image.sh` and it will build you an image.
+### ot3Image.sh
+Once you have all that, you should be able to run `./ot3Image.sh` and it will build you an image. Positional arguments to `./ot3Image.sh` will be passed (eventually) to bitbake, so you can run for instance `./ot3Image.sh --setscene-only opentrons-ot3-image` and it will run `bitbake --setscene-only opentrons-ot3-image`.
 
-You can also manually run some of the steps in `./ot3image.sh` yourself if there are some things you want to check. First, source the openembedded setup script:
+### start.sh
+If you don't want to use docker and have installed everything the docker image requires, you can also run the inner execution script, `start.sh`, directly. It requires the path to `oe-core` (this is used inside the docker container) and subsequent arguments are optionally passed to bitbake. For instance from `oe-core` you would run `start.sh .`, and to run the same command as the docker example above you
+would run `start.sh . --setscene-only opentrons-ot3-image`.
+
+### running commands directly
+
+If you also don't want to use `start.sh` (please consider adding the capability to do whatever you want to do to `start.sh`, the docker container, and `ot3Image.sh`) you can run the bitbake commands directly:
 
 `BITBAKEDIR=$(pwd)/tools/bitbake . ./layers/openembedded-core/oe-init-build-env`
 
-You'll get moved to `build`. Then you can run `bitbake`. To check recipe errors you can try `bitbake --setscene-only RECIPENAME`. You can also just change the target in `start.sh` and run `ot3image.sh`.
+You'll get moved to `build`. Then you can run `bitbake`. To check recipe errors you can try `bitbake --setscene-only RECIPENAME`.

--- a/ot3Image.sh
+++ b/ot3Image.sh
@@ -1,9 +1,12 @@
 #! /bin/bash
 
-case "$-" in
-*i*)	echo Building ot3 image ;;
-*)	echo This script uses docker run -i and will fail because this shell is not interactive ;;
-esac
-
-docker build --build-arg "username=`whoami`" --build-arg "host_uid=`id -u`"   --build-arg "host_gid=`id -g`" --tag "ot3-image:latest" .
-docker run -it --mount type=bind,src=$PWD,dst=/home/ot3/oe-core,consistency=delegated ot3-image:latest
+if [ -z ${BACKGROUND} ]; then
+    RUNSTYLE="-it"
+else
+    RUNSTYLE="-d"
+fi
+HEREPATH=$(dirname $(realpath "${0}"))
+tmp_dir=$(mktemp -d -t ci-XXXXXXX)
+cp "${HEREPATH}/start.sh" ${tmp_dir}/
+docker build -f "${HEREPATH}/Dockerfile" --build-arg "username=`whoami`" --build-arg "host_uid=`id -u`"   --build-arg "host_gid=`id -g`" --tag "ot3-image:latest" ${tmp_dir}
+docker run ${RUNSTYLE} --rm --mount type=bind,src="${HEREPATH}",dst=/volumes/oe-core,consistency=delegated ot3-image:latest "$@"

--- a/start.sh
+++ b/start.sh
@@ -20,7 +20,7 @@ cleanup () {
 DEFAULT_TARGET=opentrons-ot3-image
 THISDIR="${1}"
 shift
-TARGET="${1:-${opentrons-ot3-image}}"
+TARGET="${1:-${DEFAULT_TARGET}}"
 shift
 
 trap cleanup EXIT


### PR DESCRIPTION
You can now specify arguments to `ot3Update.sh` and have them forwarded
to bitbake. In addition, we now under the hood build the docker image
with a tempdir context that's empty except for `start.sh`, so it's a lot faster.