### PR TITLE
chore: update dockerfile to get new CA store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONT
 # without them. curl is used for brining in the repo tool. repo tool uses git, so thats being instaled here aswell.
 
 RUN apt-get update \
-    && apt-get -y upgrade \
     && apt-get -y install \
     gawk wget git-core diffstat unzip texinfo gcc-multilib \
     build-essential chrpath socat cpio python python3-pexpect \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,13 @@ RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONT
 # tar, locales and cpio are not listed in the official Yocto / Toradex BSP documentation. The build, however, fails
 # without them. curl is used for brining in the repo tool. repo tool uses git, so thats being instaled here aswell.
 
-RUN apt-get update && apt-get -y install gawk wget git-core diffstat unzip texinfo gcc-multilib \
-     build-essential chrpath socat cpio python python3-pexpect \
-     xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-     pylint3 xterm tar locales curl git sudo
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y install \
+    gawk wget git-core diffstat unzip texinfo gcc-multilib \
+    build-essential chrpath socat cpio python python3-pexpect \
+    xz-utils debianutils iputils-ping python3-git python3-jinja2 \
+    libegl1-mesa libsdl1.2-dev  pylint3 xterm tar locales curl git sudo
 
 # By default, Ubuntu uses dash as an alias for sh. Dash does not support the source command
 # needed for setting up the build environment in CMD. Use bash as an alias for sh.

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,7 @@ env:
 phases:
   pre_build:
     commands:
+      - apt-get update && apt-get upgrade -y ca-certificates
       - git config --global submodule.fetchJobs $((`nproc`-1))
       - ./update.sh
       - docker build --tag "ot3-image:latest" .


### PR DESCRIPTION
The old letsencrypt root CA expired in favor of a new one; the OS needs
updates to handle this since git.yoctoproject.org uses letsencrypt certs.