### PR TITLE
core: re-add download caching

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,10 +16,11 @@ phases:
       - docker run --mount type=bind,src=${CODEBUILD_SRC_DIR},dst=/volumes/oe-core,consistency=delegated ot3-image:latest
   post_build:
     commands:
-      - mkdir -p build/deploy/opentrons
+      - mkdir -p build/deploy/opentrons/buildstats
       - find ./build/deploy/images -name "*opentrons-ot3-image-Tezi*" -exec cp {} build/deploy/opentrons/opentrons-image.tar \;
       - find ./build/deploy/images -name opentrons-ot3-image-verdin-imx8mm.wic.bmap -exec cp {} build/deploy/opentrons \;
       - find ./build/deploy/images -name opentrons-ot3-image-verdin-imx8mm.wic.gz -exec cp {} build/deploy/opentrons \;
+      - find ./build/tmp/buildstats -exec cp {} build/deploy/opentrons/buildstats \;
 artifacts:
   base-directory: build/deploy
   files:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -31,3 +31,4 @@ artifacts:
 cache:
   paths:
     - 'downloads/**/*'
+    - 'sstate-cache/**/*'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,11 +16,11 @@ phases:
       - docker run --mount type=bind,src=${CODEBUILD_SRC_DIR},dst=/volumes/oe-core,consistency=delegated ot3-image:latest
   post_build:
     commands:
-      - mkdir -p build/deploy/opentrons/buildstats
+      - mkdir -p build/deploy/opentrons
       - find ./build/deploy/images -name "*opentrons-ot3-image-Tezi*" -exec cp {} build/deploy/opentrons/opentrons-image.tar \;
       - find ./build/deploy/images -name opentrons-ot3-image-verdin-imx8mm.wic.bmap -exec cp {} build/deploy/opentrons \;
       - find ./build/deploy/images -name opentrons-ot3-image-verdin-imx8mm.wic.gz -exec cp {} build/deploy/opentrons \;
-      - find ./build/tmp/buildstats -exec cp {} build/deploy/opentrons/buildstats \;
+      - tar czf ./build/deploy/opentrons/buildstats.tar.gz ./build/tmp/buildstats
 artifacts:
   base-directory: build/deploy
   files:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,4 +30,4 @@ artifacts:
 
 cache:
   paths:
-    - 'downloads/'
+    - 'downloads/**/*'


### PR DESCRIPTION
The thing we were missing  with previous caching effort was saving the [sstate cache](https://wiki.yoctoproject.org/wiki/Enable_sstate_cache) along with the downloads folder. By caching both sstate and downloads, we bring the builds down to about an hour. We can also save buildstats for later perusal and put them in the artifact store.