### PR TITLE
buildspec: only upgrade ca-certificates not kernel

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ env:
 phases:
   pre_build:
     commands:
-      - apt-get update && apt-get upgrade -y ca-certificates
+      - apt-get update && apt-get -y --only-upgrade install ca-certificates
       - git config --global submodule.fetchJobs $((`nproc`-1))
       - ./update.sh
       - docker build --tag "ot3-image:latest" .


### PR DESCRIPTION
The AWS EC2 vms that back codebuild still have ubuntu glibc with [bug 1962606](https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1962606) which means that if you blindly upgrade everything (which `apt-get upgrade` does, even if you give it a specific package name) then `apt-get` will fail because the kernel minor version is too high. If you instead use `apt-get install --only-upgrade <packagename>` then it will only try to upgrade that package, and not the kernel, and the problem is avoided... for now anyway. Probably the better path in the future is a different method to make sure ca-certificates is up to date or a more docker-native setup.