### PR TITLE
RET-1205 Remove recipe source files are they are built to save diskspace

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -41,9 +41,6 @@ MACHINE ?= "verdin-imx8mm"
 #MACHINE ?= "qemux86"
 #MACHINE ?= "qemux86-64"
 
-INHERIT += "toradex-mirrors rm_work"
-# exlude opentrons-ot3-image
-RM_WORK_EXCLUDE += "opentrons-ot3-image"
 
 MACHINEOVERRIDES =. "use-head-next:"
 #
@@ -266,9 +263,12 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 CONF_VERSION = "1"
 
 # Delete the the source/object/binary files once a package is built to preserve disk space
+INHERIT += "rm_work"
+# exlude opentrons-ot3-image
+RM_WORK_EXCLUDE += "opentrons-ot3-image"
 
 # Add Toradex source mirror
-INHERIT += "toradex-mirrors rm_work"
+INHERIT += "toradex-mirrors"
 
 # Use this distro
 DISTRO = "opentrons"

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -265,7 +265,7 @@ CONF_VERSION = "1"
 # Delete the the source/object/binary files once a package is built to preserve disk space
 
 # Add Toradex source mirror
-INHERIT += "toradex-mirrors"
+INHERIT += "toradex-mirrors rm_work"
 
 # Use this distro
 DISTRO = "opentrons"

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -41,7 +41,10 @@ MACHINE ?= "verdin-imx8mm"
 #MACHINE ?= "qemux86"
 #MACHINE ?= "qemux86-64"
 
-INHERIT += "toradex-mirrors"
+INHERIT += "toradex-mirrors rm_work"
+# exlude opentrons-ot3-image
+RM_WORK_EXCLUDE += "opentrons-ot3-image"
+
 MACHINEOVERRIDES =. "use-head-next:"
 #
 # Where to place downloads


### PR DESCRIPTION
[RET-1205](https://opentrons.atlassian.net/browse/RET-1205)

CI build [oe-core-run:8039613853](https://github.com/Opentrons/oe-core/runs/8039613853) is failing because we run out of diskspace. So add rm_recipe to the local.conf file which will remove recipe source files after the recipe is built.