### PR TITLE
update version files fix for subsequent builds

### DIFF
--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -6,6 +6,9 @@ inherit distutils3-base
 DEPENDS += "python3 python3-native python3-pip-native python3-micropipenv-native "
 RDEPENDS_${PN} += " python3 python3-modules"
 
+# directory for version file output
+SYSROOT_DIRS += "/opentrons_versions"
+
 # Whether pipenv or poetry is the appropriate underlying dependency manager
 # parse
 PIPENV_APP_BUNDLE_PACKAGE_SOURCE ??= "pipenv"
@@ -170,4 +173,4 @@ do_install () {
         -exec install "{}" "${D}${PIPENV_APP_BUNDLE_DIR}/{}" \;
 }
 
-FILES_${PN} = "${PIPENV_APP_BUNDLE_DIR}"
+FILES_${PN} = "${PIPENV_APP_BUNDLE_DIR} /opentrons_versions"

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server_git.bb
@@ -30,8 +30,6 @@ PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRAS = "./../hardware"
 
 do_compile_append() {
-    # create json file to be used in VERSION.json
-    python3 ${S}/scripts/python_build_utils.py robot-server dump_br_version > ${DEPLOY_DIR_IMAGE}/opentrons-robot-server-version.json
     # dont include scripts
     rm -rf ${PIPENV_APP_BUNDLE_SOURCE_VENV}/opentrons/resources/scripts
 }
@@ -39,6 +37,10 @@ do_compile_append() {
 addtask do_write_systemd_dropfile after do_compile before do_install
 
 do_install_append () {
+    # create json file to be used in VERSION.json
+    install -d ${D}/opentrons_versions
+    python3 ${S}/scripts/python_build_utils.py robot-server dump_br_version > ${D}/opentrons_versions/opentrons-robot-server-version.json
+
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-robot-server.service ${D}${systemd_system_unitdir}/opentrons-robot-server.service
     install -d ${D}${systemd_system_unitdir}/opentrons-robot-server.service.d

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server_git.bb
@@ -30,12 +30,11 @@ PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRAS = ""
 PIPENV_APP_BUNDLE_USE_GLOBAL = "python3-aiohttp systemd-python"
 
-do_compile_append() {
-  # create json file to be used in VERSION.jso
-  python3 ${S}/scripts/python_build_utils.py update-server dump_br_version > ${DEPLOY_DIR_IMAGE}/opentrons-update-server-version.json
-}
-
 do_install_append() {
+  # create json file to be used in VERSION.json
+  install -d ${D}/opentrons_versions
+  python3 ${S}/scripts/python_build_utils.py update-server dump_br_version > ${D}/opentrons_versions/opentrons-update-server-version.json
+
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/opentrons-update-server.service ${D}/${systemd_unitdir}/system
 }


### PR DESCRIPTION
**Overview**
The version file we are looking for in the do_create_manifest task is created during the do_compile task in the robot-server and update-server recipes. The version files are stored in the deployment directory deploy/images/verdin-imx8mm/ which is not cached. Since we are using sstate_cache the **do_compile** task, which is where the version files are created, does not re-run, which means the files are never created.

**Changes**
- move server version file generation from do_compile to do_install to take advantage of sstate_cache
- use sysroot and sysroot_target_host to reference generated version files from the opentrons-ot3-image recipe