### PR TITLE
recipes-robot: A few changes around the stack to address On-Device-Display issues

### DIFF
--- a/layers/meta-opentrons/conf/machine/verdin-imx8mm.conf
+++ b/layers/meta-opentrons/conf/machine/verdin-imx8mm.conf
@@ -86,6 +86,7 @@ TEZI_EXTERNAL_KERNEL_DEVICETREE_BOOT = "\
   verdin-imx8mm_sn65dsi84_overlay.dtbo \
   verdin-imx8mm_gt911_overlay.dtbo \
   verdin-imx8mm_MCP2518_overlay.dtbo \
+  verdin-imx8mm_force-lcd-on.dtbo \
 "
 
 TORADEX_PRODUCT_IDS = "0055 0057 0059 0060"

--- a/layers/meta-opentrons/recipes-graphics/wayland/files/imx/weston.ini
+++ b/layers/meta-opentrons/recipes-graphics/wayland/files/imx/weston.ini
@@ -8,10 +8,9 @@ idle-time=0
 #[shell]
 #size=1920x1080
 
-#[output]
-#name=HDMI-A-1
-#mode=1920x1080@60
-#transform=90
+[output]
+name=DSI-1
+transform=rotate-180
 
 #[output]
 #name=HDMI-A-2

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -37,7 +37,7 @@ IMAGE_INSTALL += " \
     python3 python3-misc python3-modules \
  "
 
-ROBOT_MODEL = "OT-3 Standard"
+ROBOT_TYPE = "OT-3 Standard"
 # Prefix to the resulting deployable tarball name
 export IMAGE_BASENAME = "opentrons-ot3-image"
 MACHINE_NAME ?= "${MACHINE}"

--- a/layers/meta-opentrons/recipes-kernel/linux/device-tree-overlays_git.bbappend
+++ b/layers/meta-opentrons/recipes-kernel/linux/device-tree-overlays_git.bbappend
@@ -3,6 +3,7 @@ SRC_URI_append = "\
   file://verdin-imx8mm_gt911_overlay.dts \
   file://verdin-imx8mm_MCP2518_overlay.dts \
   file://verdin-imx8mm_usbotg1-force-peripheral.dts \
+  file://verdin-imx8mm_force-lcd-on.dts \
   "
 
 FILESEXTRAPATHS_append := ":${THISDIR}/overlays"

--- a/layers/meta-opentrons/recipes-kernel/linux/overlays/verdin-imx8mm_force-lcd-on.dts
+++ b/layers/meta-opentrons/recipes-kernel/linux/overlays/verdin-imx8mm_force-lcd-on.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2
+/*
+ * Copyright 2020-2022 Opentrons
+ */
+
+// Pull DISPL_RST_CTRL_SOM (SODIMM_44) high so the LCD turns on during startup
+
+/dts-v1/;
+/plugin/;
+
+#include <imx8mm-pinfunc.h>
+#include "dt-bindings/gpio/gpio.h"
+
+/ {
+	compatible = "toradex,verdin-imx8mm";
+};
+
+&pinctrl_sai5 {
+	fsl,pins = <
+		MX8MM_IOMUXC_SAI5_RXD1_GPIO3_IO22               0x146   /* SODIMM 44 */
+	>;
+};
+
+&sai5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_sai5>;
+	enable-gpios = <&gpio3 22 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};

--- a/layers/meta-opentrons/recipes-robot/robot-app/robot-app-wayland-launch_1.0.bb
+++ b/layers/meta-opentrons/recipes-robot/robot-app/robot-app-wayland-launch_1.0.bb
@@ -20,7 +20,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 APPLICATION_ENVIRONMENT := '\"DISPLAY=\:0\:0\" \"XDG_SESSION_TYPE=wayland\" \"XDG_SESSION_DESKTOP=kiosk\" \"PYTHONPATH=/opt/opentrons-robot-server\"'
 
-WAYLAND_APPLICATION := "/opt/opentrons-app/opentrons --discovery.candidates=localhost --discovery.ipFilter=\"127.0.0.1\" --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=wayland --in-process-gpu --python.pathToPythonOverride=/usr/bin/python3"
+WAYLAND_APPLICATION := "/opt/opentrons-app/opentrons --discovery.candidates=localhost --discovery.ipFilter=\"127.0.0.1\" --isOnDevice=1 --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=wayland --in-process-gpu --python.pathToPythonOverride=/usr/bin/python3"
 
 do_compile () {
     sed -e "s:@@wayland-application@@:${WAYLAND_APPLICATION}:" -e "s:@@initial-path@@:${INITIAL_PATH}:" opentrons-robot-app.sh.in > opentrons-robot-app.sh


### PR DESCRIPTION
[RCORE-343](https://opentrons.atlassian.net/browse/RCORE-343)

**Overview**
Addressing some issues discovered after updating the rootfs from the opentrons desktop app

**Changes**
- Change ROBOT_MODEL to ROBOT_TYPE so we put the correct value when creating the VERSION.json file
- Added DSI-1 output to weston.ini to rotate the On-Device-Display -180 degrees so it shows up with the correct orientation 
- Added IsOnDevice=1 flag when starting opentrons-robot-app.sh script so the app knows its running on the ODD
- Added overlay to drive - DISPL_RST_CTRL_SOM - SODIMM_44 high on startup so the LCD turns on

**Todo**
- [x] validate the overlay change on the actual ODD hardware