### PR TITLE
build: cache using zips to fix git cache issues

### DIFF
--- a/.github/actions/aws-credentials/action.yml
+++ b/.github/actions/aws-credentials/action.yml
@@ -28,7 +28,7 @@ runs:
         aws configure set output json --profile identity
       shell: bash
     - name: configure dev creds
-      if: ${{ contains('dev', inputs.stage) }}
+      if: ${{ contains(inputs.stage, 'dev') }}
       run: |
         echo "setting creds for dev based on stage being ${{ inputs.stage }}"
         aws configure set region us-east-2 --profile deploy
@@ -36,7 +36,7 @@ runs:
         aws configure set source_profile identity --profile deploy
       shell: bash
     - name: configure staging or prod creds
-      if: ${{ !contains('dev', inputs.stage) }}
+      if: ${{ !contains(inputs.stage, 'dev') }}
       run: |
         echo "setting creds for prod and staging based on stage being ${{ inputs.stage }}"
         aws configure set region us-east-2 --profile deploy

--- a/.github/actions/aws-credentials/action.yml
+++ b/.github/actions/aws-credentials/action.yml
@@ -30,6 +30,7 @@ runs:
     - name: configure dev creds
       if: ${{ contains('dev', inputs.stage) }}
       run: |
+        echo "setting creds for dev based on stage being ${{ inputs.stage }}"
         aws configure set region us-east-2 --profile deploy
         aws configure set role_arn arn:aws:iam::699250785121:role/administrator --profile deploy
         aws configure set source_profile identity --profile deploy
@@ -37,6 +38,7 @@ runs:
     - name: configure staging or prod creds
       if: ${{ !contains('dev', inputs.stage) }}
       run: |
+        echo "setting creds for prod and staging based on stage being ${{ inputs.stage }}"
         aws configure set region us-east-2 --profile deploy
         aws configure set role_arn arn:aws:iam::879285218407:role/administrator --profile deploy
         aws configure set source_profile identity --profile deploy

--- a/.github/actions/aws-credentials/action.yml
+++ b/.github/actions/aws-credentials/action.yml
@@ -26,19 +26,23 @@ runs:
         aws configure set aws_secret_access_key ${{ inputs.secret_access_key }} --profile identity
         aws configure set region ${{ inputs.region }} --profile identity
         aws configure set output json --profile identity
+      shell: bash
     - name: configure dev creds
       if: ${{ contains('dev', inputs.stage) }}
       run: |
         aws configure set region us-east-2 --profile deploy
         aws configure set role_arn arn:aws:iam::699250785121:role/administrator --profile deploy
         aws configure set source_profile identity --profile deploy
+      shell: bash
     - name: configure staging or prod creds
       if: ${{ !contains('dev', inputs.stage) }}
       run: |
         aws configure set region us-east-2 --profile deploy
         aws configure set role_arn arn:aws:iam::879285218407:role/administrator --profile deploy
         aws configure set source_profile identity --profile deploy
+      shell: bash
     - name: set output profile
       id: decide-profile-name
       run: |
         echo "profile_name=deploy" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/aws-credentials/action.yml
+++ b/.github/actions/aws-credentials/action.yml
@@ -1,0 +1,44 @@
+name: "Set AWS credentials for robot-stack"
+description: "Set role credentials for the infra used for builds"
+inputs:
+  access_key_id:
+    description: "access key id from secrets"
+    required: true
+  secret_access_key:
+    description: "secret access key from secrets"
+    required: true
+  region:
+    description: "aws region to use"
+    required: true
+  stage:
+    description: "which of stage-dev, stage-staging, or stage-prod this is"
+    required: true
+outputs:
+  profile_name:
+    description: "the name of the profile to use in aws cli commands"
+    value: "${{steps.decide-profile-name.outputs.profile_name}}"
+runs:
+  using: "composite"
+  steps:
+    - name: configure root creds
+      run: |
+        aws configure set aws_access_key_id ${{ inputs.access_key_id }} --profile identity
+        aws configure set aws_secret_access_key ${{ inputs.secret_access_key }} --profile identity
+        aws configure set region ${{ inputs.region }} --profile identity
+        aws configure set output json --profile identity
+    - name: configure dev creds
+      if: ${{ contains('dev', inputs.stage) }}
+      run: |
+        aws configure set region us-east-2 --profile deploy
+        aws configure set role_arn arn:aws:iam::699250785121:role/administrator --profile deploy
+        aws configure set source_profile identity --profile deploy
+    - name: configure staging or prod creds
+      if: ${{ !contains('dev', inputs.stage) }}
+      run: |
+        aws configure set region us-east-2 --profile deploy
+        aws configure set role_arn arn:aws:iam::879285218407:role/administrator --profile deploy
+        aws configure set source_profile identity --profile deploy
+    - name: set output profile
+      id: decide-profile-name
+      run: |
+        echo "profile_name=deploy" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Sync oe-core submodules
         run: |
+          chown `whoami` .
           whoami
           ls -la .
           ./update.sh

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -53,7 +53,7 @@ jobs:
           aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
           cachedir=${LOCAL_CACHE:-./cache}
           for cachetype in downloads sstate git ; do
-              localzip=${cachedir}/${cachetype}.zip
+              localzip=${cachedir}/../${cachetype}.zip
               thiscache=${cachedir}/${cachetype}
               echo "Fetching cache for ${cachetype}"
               df -h
@@ -72,17 +72,13 @@ jobs:
       - name: Prune images
         if: always()
         run: docker image prune -af
-      - name: Remove poisoned cache
-        if: ${{ !success() }}
-        run: |
-          rm -rf ${LOCAL_CACHE:-./cache}/*
       - name: Push S3 cache
         shell: bash
         run: |
           aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
           cachedir=${LOCAL_CACHE:-./cache}
           for cachetype in downloads sstate git ; do
-              localzip=${cachedir}/${cachetype}.zip
+              localzip=${cachedir}/../${cachetype}.zip
               thiscache=${cachedir}/${cachetype}
               cd ${thiscache}
               echo "Refreshing cache for ${cachetype}"
@@ -120,3 +116,7 @@ jobs:
         if: always()
         run: |
           rm -rf ./*
+      - name: Remove poisoned cache
+        if: ${{ !success() }}
+        run: |
+          rm -rf ${LOCAL_CACHE:-./cache}/*

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -53,15 +53,14 @@ jobs:
           aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
           cachedir=${LOCAL_CACHE:-./cache}
           for cachetype in downloads sstate git ; do
-              localzip=${cachedir}/../${cachetype}.zip
+              localzip=$(realpath ${cachedir}/../${cachetype}.zip)
               thiscache=${cachedir}/${cachetype}
-              echo "Fetching cache for ${cachetype}"
-              df -h
+              echo "Fetching cache for ${cachetype} to ${localzip}"
               mkdir -p ${thiscache}
-              $aws_cp s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip ${localzip} || continue
-              df -h
-              unzip -q -u -o ${localzip} -d ${thiscache}
-              df -h
+              TIME="%E" time $aws_cp s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip ${localzip} 2>elapsed || continue
+              echo "Fetched $(du -h ${localzip} | cut -f 1)B in $(cat elapsed), extracting to ${thiscache}" || 0
+              TIME="%E" time unzip -q -u -o ${localzip} -d ${thiscache} 2>elapsed
+              echo "Extracted $(du -h -d 1 $thiscache | tail -n 1 | cut -f 1)B to ${thiscache} in $(cat elapsed)" || 0
           done
       - name: Download sources
         run: |
@@ -74,18 +73,20 @@ jobs:
         run: docker image prune -af
       - name: Push S3 cache
         shell: bash
+        continue-on-error: true
         run: |
           aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
           cachedir=${LOCAL_CACHE:-./cache}
           for cachetype in downloads sstate git ; do
-              localzip=${cachedir}/../${cachetype}.zip
+              df -h
+              localzip=$(realpath ${cachedir}/../${cachetype}.zip)
               thiscache=${cachedir}/${cachetype}
               cd ${thiscache}
-              echo "Refreshing cache for ${cachetype}"
-              df -h
-              zip -q -r --filesync --symlinks  ${localzip} ./*
-              df -h
-              ${aws_cp} ${localzip} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip
+              echo "Refreshing cache for ${cachetype} from ${thiscache} to ${localzip}"
+              TIME="%E" time zip -q -r --filesync --symlinks  ${localzip} ./* 2>elapsed
+              echo "Refreshed cache in $(cat elapsed)" || 0
+              TIME="%E" time ${aws_cp} ${localzip} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip 2>elapsed
+              echo "Uploaded $(du -h $localzip | cut -f 1)B in $(cat elapsed)" || 0
           done
       - name: Gather results
         run: |

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Sync oe-core submodules
         run: |
+          whoami
           ls -l .
           ./update.sh
       - name: Configure AWS Credentials

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -57,7 +57,7 @@ jobs:
         if: always()
         run: docker image prune -af
       - name: Remove poisoned cache
-        if: failure()
+        if: ${{ !success() }}
         run: |
           rm -rf ${LOCAL_CACHE:-./cache}/*
       - name: Push S3 cache

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -58,7 +58,7 @@ jobs:
               echo "Fetching cache for ${cachetype}"
               mkdir -p ${thiscache}
               $aws_cp s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip ${localzip} || continue
-              unzip ${localzip} -u -o -d ${thiscache}
+              unzip -u -o ${localzip} -d ${thiscache}
               df -h
           done
       - name: Download sources

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -12,7 +12,7 @@ jobs:
   run-build:
     strategy:
       matrix:
-        build_env: ['stage-prod', 'stage-staging', 'stage-dev']
+        build_env: ['stage-prod']
     name: 'Building images on ${{ matrix.build_env }}'
     timeout-minutes: 480
     runs-on: ['self-hosted', '${{matrix.build_env}}']
@@ -47,12 +47,17 @@ jobs:
           synccommand="aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete s3://${S3_CACHE_ARN/arn:aws:s3:::/} ${LOCAL_CACHE:-./cache}"
           echo $synccommand
           $synccommand
+          du -h
       - name: Download sources
         run: |
           docker run --rm --mount type=bind,src=$(pwd),dst=/volumes/oe-core,consistency=delegated --mount type=bind,src=${LOCAL_CACHE:-./cache},dst=/volumes/cache,consistency=delegated ot3-image:latest opentrons-ot3-image --runall=fetch
       - name: Build image
         run: |
           docker run --rm --mount type=bind,src=$(pwd),dst=/volumes/oe-core,consistency=delegated --mount type=bind,src=${LOCAL_CACHE:-./cache},dst=/volumes/cache,consistency=delegated ot3-image:latest
+      - name: debug download failures
+        if: always()
+        run: |
+          du -h
       - name: Prune images
         if: always()
         run: docker image prune -af

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -50,15 +50,17 @@ jobs:
       - name: Pull S3 cache
         shell: bash
         run: |
-          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp"
+          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
           cachedir=${LOCAL_CACHE:-./cache}
           for cachetype in downloads sstate git ; do
               localzip=${cachedir}/${cachetype}.zip
               thiscache=${cachedir}/${cachetype}
               echo "Fetching cache for ${cachetype}"
+              df -h
               mkdir -p ${thiscache}
               $aws_cp s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip ${localzip} || continue
-              unzip -u -o ${localzip} -d ${thiscache}
+              df -h
+              unzip -q -u -o ${localzip} -d ${thiscache}
               df -h
           done
       - name: Download sources
@@ -77,14 +79,16 @@ jobs:
       - name: Push S3 cache
         shell: bash
         run: |
-          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp"
+          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
           cachedir=${LOCAL_CACHE:-./cache}
           for cachetype in downloads sstate git ; do
               localzip=${cachedir}/${cachetype}.zip
               thiscache=${cachedir}/${cachetype}
               cd ${thiscache}
               echo "Refreshing cache for ${cachetype}"
-              zip -r --filesync --symlinks  ${localzip} ./*
+              df -h
+              zip -q -r --filesync --symlinks  ${localzip} ./*
+              df -h
               ${aws_cp} ${localzip} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip
           done
       - name: Gather results

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Sync oe-core submodules
         run: |
           whoami
-          ls -l .
+          ls -la .
           ./update.sh
       - name: Configure AWS Credentials
         uses: './.github/actions/aws-credentials'

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -97,3 +97,7 @@ jobs:
           payload: "{\"s3-url\":\"${{ steps.upload-results.outputs.console_url }}/\",\"type\":\"branch\", \"reflike\":\"${{ github.ref }}\", \"full-image\":\"${{ steps.upload-results.outputs.fullimage_url }}\", \"system-update\":\"${{ steps.upload-results.outputs.system_url }}\", \"version-file\":\"${{ steps.upload-results.outputs.version_file_url }}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Remove build data
+        if: always()
+        run: |
+          rm -rf .

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Configure AWS Credentials
-        uses: '.github/actions/aws-credentials'
+        uses: './.github/actions/aws-credentials'
         id: aws
         with:
           access_key_id: ${{ secrets.ROBOT_STACK_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -24,7 +24,9 @@ jobs:
           fetch-depth: 0
       - name: Sync oe-core submodules
         run: |
-          chown `whoami` .
+          chown -R `whoami` .
+          whoami
+          ls -la .
           ./update.sh
       - name: Configure AWS Credentials
         uses: './.github/actions/aws-credentials'

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Sync oe-core submodules
         run: |
+          ls -l .
           ./update.sh
       - name: Configure AWS Credentials
         uses: './.github/actions/aws-credentials'

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           echo "" >> ./build/conf/local.conf
           echo 'DL_DIR = "/volumes/cache/downloads"' >> ./build/conf/local.conf
+          echo 'GIT_DIR = "/volumes/cache/git"' >> ./build/conf/local.conf
           echo 'SSTATE_DIR = "/volumes/cache/sstate"' >> ./build/conf/local.conf
       - name: Pull S3 cache
         shell: bash
@@ -62,7 +63,7 @@ jobs:
       - name: Push S3 cache
         shell: bash
         run: |
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete --no-follow-symlinks ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
       - name: Gather results
         run: |
           mkdir -p build/deploy/opentrons

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "" >> ./build/conf/local.conf
           echo 'DL_DIR = "/volumes/cache/downloads"' >> ./build/conf/local.conf
-          echo 'GIT_DIR = "/volumes/cache/git"' >> ./build/conf/local.conf
+          echo 'GITDIR = "/volumes/cache/git"' >> ./build/conf/local.conf
           echo 'SSTATE_DIR = "/volumes/cache/sstate"' >> ./build/conf/local.conf
       - name: Pull S3 cache
         shell: bash

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Pull S3 cache
         shell: bash
         run: |
-          synccommand="aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync s3://${S3_CACHE_ARN/arn:aws:s3:::/} ${LOCAL_CACHE:-./cache}"
+          synccommand="aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete s3://${S3_CACHE_ARN/arn:aws:s3:::/} ${LOCAL_CACHE:-./cache}"
           echo $synccommand
           $synccommand
       - name: Download sources
@@ -62,7 +62,7 @@ jobs:
       - name: Push S3 cache
         shell: bash
         run: |
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
       - name: Gather results
         run: |
           mkdir -p build/deploy/opentrons

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -23,24 +23,13 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Configure AWS Credentials
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.ROBOT_STACK_AWS_ACCESS_KEY_ID }} --profile identity
-          aws configure set aws_secret_access_key ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }} --profile identity
-          aws configure set region us-east-2 --profile identity
-          aws configure set output json --profile identity
-        shell: bash
-      - name: Add dev infra config
-        if: matrix.build_env == 'stage-dev'
-        run: |
-          aws configure set region us-east-2 --profile deploy
-          aws configure set role_arn arn:aws:iam::699250785121:role/administrator --profile deploy
-          aws configure set source_profile identity --profile deploy
-      - name: add staging or prod infra config
-        if: matrix.build_env != 'stage-dev'
-        run: |
-          aws configure set region us-east-2 --profile deploy
-          aws configure set role_arn arn:aws:iam::879285218407:role/administrator --profile deploy
-          aws configure set source_profile identity --profile deploy
+        uses: '.github/actions/aws-credentials'
+        id: aws
+        with:
+          access_key_id: ${{ secrets.ROBOT_STACK_AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }}
+          region: us-east-2
+          stage: ${{ matrix.build_env }}
         shell: bash
       - name: Build container
         run: |
@@ -55,7 +44,7 @@ jobs:
       - name: Pull S3 cache
         shell: bash
         run: |
-          synccommand="aws --profile=deploy s3 sync s3://${S3_CACHE_ARN/arn:aws:s3:::/} ${LOCAL_CACHE:-./cache}"
+          synccommand="aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync s3://${S3_CACHE_ARN/arn:aws:s3:::/} ${LOCAL_CACHE:-./cache}"
           echo $synccommand
           $synccommand
       - name: Download sources
@@ -74,7 +63,7 @@ jobs:
       - name: Push S3 cache
         shell: bash
         run: |
-          aws --profile=deploy s3 sync ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
       - name: Gather results
         run: |
           mkdir -p build/deploy/opentrons
@@ -87,7 +76,7 @@ jobs:
         id: 'upload-results'
         run: |
           cd build/deploy/
-          aws --profile=deploy s3 cp --acl=public-read --recursive opentrons s3://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot3-oe/${{ github.run_id }}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read --recursive opentrons s3://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot3-oe/${{ github.run_id }}
           root_url=https://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot3-oe/${{ github.run_id }}
           echo "console_url=https://s3.console.aws.amazon.com/s3/buckets/${S3_ARTIFACT_ARN/arn:aws:s3::::/}?prefix=${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "version_file_url=$root_url/VERSION.json" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -50,10 +50,17 @@ jobs:
       - name: Pull S3 cache
         shell: bash
         run: |
-          synccommand="aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete s3://${S3_CACHE_ARN/arn:aws:s3:::/} ${LOCAL_CACHE:-./cache}"
-          echo $synccommand
-          $synccommand
-          du -h
+          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp"
+          cachedir=${LOCAL_CACHE:-./cache}
+          for cachetype in downloads sstate git ; do
+              localzip=${cachedir}/${cachetype}.zip
+              thiscache=${cachedir}/${cachetype}
+              echo "Fetching cache for ${cachetype}"
+              mkdir ${thiscache}
+              $aws_cp s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip ${localzip} || continue
+              unzip ${localzip} -u -o -d ${thiscache}
+              df -h
+          done
       - name: Download sources
         run: |
           docker run --rm --mount type=bind,src=$(pwd),dst=/volumes/oe-core,consistency=delegated --mount type=bind,src=${LOCAL_CACHE:-./cache},dst=/volumes/cache,consistency=delegated ot3-image:latest opentrons-ot3-image --runall=fetch
@@ -70,7 +77,16 @@ jobs:
       - name: Push S3 cache
         shell: bash
         run: |
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 sync --delete --no-follow-symlinks ${LOCAL_CACHE:-./cache} s3://${S3_CACHE_ARN/arn:aws:s3:::/}
+          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp"
+          cachedir=${LOCAL_CACHE:-./cache}
+          for cachetype in downloads sstate git ; do
+              localzip=${cachedir}/${cachetype}.zip
+              thiscache=${cachedir}/${cachetype}
+              cd ${thiscache}
+              echo "Refreshing cache for ${cachetype}"
+              zip -r --filesync --symlinks  ${localzip} ./*
+              ${aws_cp} ${localzip} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip
+          done
       - name: Gather results
         run: |
           mkdir -p build/deploy/opentrons

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Sync oe-core submodules
         run: |
           chown `whoami` .
-          whoami
-          ls -la .
           ./update.sh
       - name: Configure AWS Credentials
         uses: './.github/actions/aws-credentials'
@@ -60,10 +58,6 @@ jobs:
       - name: Build image
         run: |
           docker run --rm --mount type=bind,src=$(pwd),dst=/volumes/oe-core,consistency=delegated --mount type=bind,src=${LOCAL_CACHE:-./cache},dst=/volumes/cache,consistency=delegated ot3-image:latest
-      - name: debug download failures
-        if: always()
-        run: |
-          du -h
       - name: Prune images
         if: always()
         run: docker image prune -af

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -56,7 +56,7 @@ jobs:
               localzip=${cachedir}/${cachetype}.zip
               thiscache=${cachedir}/${cachetype}
               echo "Fetching cache for ${cachetype}"
-              mkdir ${thiscache}
+              mkdir -p ${thiscache}
               $aws_cp s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip ${localzip} || continue
               unzip ${localzip} -u -o -d ${thiscache}
               df -h

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -30,7 +30,6 @@ jobs:
           secret_access_key: ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }}
           region: us-east-2
           stage: ${{ matrix.build_env }}
-        shell: bash
       - name: Build container
         run: |
           tmp_dir=$(mktemp -d -t ci-XXXXXXX)

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Fetch sources
         uses: 'actions/checkout@v3'
         with:
-          submodules: true
+          submodules: false
           fetch-depth: 0
+      - name: Sync oe-core submodules
+        run: |
+          ./update.sh
       - name: Configure AWS Credentials
         uses: './.github/actions/aws-credentials'
         id: aws

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -100,4 +100,4 @@ jobs:
       - name: Remove build data
         if: always()
         run: |
-          rm -rf .
+          rm -rf ./*


### PR DESCRIPTION
A series of fixes based on needed refactors and some recent build failures:
- refactor: move the aws credentialing code into an action since it was so bulky
- split caches of non-git downloads, sstate, and git downloads into separate entities
- store these entities on s3 as zips, since they contain empty directory trees that s3 will otherwise not store