### PR TITLE
recipes-bsp/u-boot: added custom u-boot script to change boot behavior

### DIFF
--- a/layers/meta-opentrons/recipes-bsp/u-boot/files/boot.cmd.in
+++ b/layers/meta-opentrons/recipes-bsp/u-boot/files/boot.cmd.in
@@ -1,0 +1,165 @@
+# Toradex Boot Script adapted for the Opentrons OT3
+# Boot Steps:
+# - Find active rootfs from emmc based on the root_part env var
+# - Load the kernel (Image.gz) + DTB + Overlays from the rootfs
+# - Boot the loaded kernel from the rootfs
+# - If boot fails, switch the root_part env var (2-3) and retry boot
+#
+# Common flags:
+# - Boot from rootfs: boot_from_rootfs := {1, 0}
+#   1 - loads the kernel + dtb + overlays from the active rootfs as determined by root_part env. [DEFAULT]
+#   0 - loads the kernel + dtb + overlays from the boot partition.
+# - Boot files: rootfs_boot_dir := {"/boot"}
+#   "/boot" - directory in the rootfs to look for the kernel + dtb + overlays
+
+# SPDX-License-Identifier: GPL-2.0+ OR MIT
+#
+# Copyright 2020 Toradex
+#
+# Toradex boot script.
+#
+# Allows to change boot and rootfs devices independently.
+# Supports:
+# - boot device type: boot_devtype := {mmc, usb, tftp, dhcp}
+# - boot device num (for mmc, usb types): boot_devnum := {0 .. MAX_DEV_NUM}
+# - boot partition (for mmc, usb types): boot_part := {1 .. MAX_PART_NUM}
+# - root device type: root_devtype := {mmc, usb, nfs-dhcp, nfs-static}
+# - root device num (for mmc, usb types): root_devnum := {0 .. MAX_DEV_NUM}
+# - root partition (for mmc, usb types): root_part := {1 .. MAX_PART_NUM}
+#
+# Defaults:
+#    root_devtype = boot_devtype = devtype
+#    root_devnum = boot_devnum = devnum
+#    boot_part = distro_bootpart
+#    root_part = 2
+#
+# Common variables used in tftp/dhcp modes:
+# - Static/dynamic IP mode: ip_dyn := {yes, no}
+# - Static IP-address of TFTP/NFS server: serverip := {legal IPv4 address}
+# - Static IP-address of the module: ipaddr := {legal IPv4 address}
+# - Root-path on NFS-server: rootpath := {legal path, exported by an NFS-server}
+#
+# Common flags:
+# - Skip loading overlays: skip_fdt_overlays := {1, 0}
+#   1 - skip, any other value (or undefined variable) - don't skip.
+#   This variable is adopted from the TorizonCore and shouldn't be
+#   renamed separately.
+
+if test ${devtype} = "ubi"; then
+    echo "This script is not meant to distro boot from raw NAND flash."
+    exit
+fi
+
+test -n ${m4boot} || env set m4boot ';'
+test -n ${fdtfile} || env set fdtfile ${fdt_file}
+test -n ${boot_part} || env set boot_part ${distro_bootpart}
+test -n ${root_part} || env set root_part 2
+test -n ${boot_devnum} || env set boot_devnum ${devnum}
+test -n ${root_devnum} || env set root_devnum ${devnum}
+test -n ${kernel_image} || env set kernel_image @@KERNEL_IMAGETYPE@@
+test -n ${boot_devtype} || env set boot_devtype ${devtype}
+test -n ${boot_from_rootfs} || env set boot_from_rootfs 1
+test -n ${rootfs_boot_dir} || env set rootfs_boot_dir "/boot"
+test ${boot_from_rootfs} = 0 && env set rootfs_boot_dir ""
+test -n ${overlays_file} || env set overlays_file "${rootfs_boot_dir}/overlays.txt"
+test -n ${overlays_prefix} || env set overlays_prefix "${rootfs_boot_dir}/overlays/"
+
+# load kernel from rootfs or boot partition
+if test "${boot_devtype}" = "mmc"; then
+    if test "${boot_from_rootfs}" = 1; then
+        env set load_cmd 'ext4load ${boot_devtype} ${root_devnum}:${root_part}'
+    else
+        env set load_cmd 'load ${boot_devtype} ${boot_devnum}:${boot_part}'
+    fi
+fi
+
+test ${boot_devtype} = "usb" && env set load_cmd 'load ${boot_devtype} ${boot_devnum}:${boot_part}'
+test ${boot_devtype} = "tftp" && env set load_cmd 'tftp'
+test ${boot_devtype} = "dhcp" && env set load_cmd 'dhcp'
+
+# Set Root source type properly.
+# devtype tftp => nfs-static
+# devtype ghcp => nfs-dhcp
+if test "${root_devtype}" = ""; then
+    if test ${devtype} = "tftp"; then
+        env set root_devtype "nfs-static"
+    else
+        if test ${devtype} = "dhcp"; then
+            env set root_devtype "nfs-dhcp"
+        else
+            env set root_devtype ${devtype}
+        fi
+    fi
+fi
+
+if test -n ${setup}; then
+    run setup
+else
+    env set setupargs 'console=${console},${baudrate} console=tty1 consoleblank=0'
+fi
+
+if test ${kernel_image} = "Image.gz"
+then
+    env set kernel_addr_load ${loadaddr}
+    env set bootcmd_unzip 'unzip ${kernel_addr_load} ${kernel_addr_r}'
+else
+    env set bootcmd_unzip ';'
+    if test ${kernel_image} = "fitImage"
+    then
+        env set kernel_addr_load ${ramdisk_addr_r}
+    else
+        env set kernel_addr_load ${kernel_addr_r}
+    fi
+fi
+
+# Set dynamic commands
+env set set_bootcmd_kernel 'env set bootcmd_kernel "${load_cmd} \\${kernel_addr_load} \\${rootfs_boot_dir}/\\${kernel_image}"'
+env set set_load_overlays_file 'env set load_overlays_file "${load_cmd} \\${loadaddr} \\${overlays_file}; env import -t \\${loadaddr} \\${filesize}"'
+if test ${kernel_image} = "fitImage"
+then
+    env set fdt_high
+    env set fdt_resize true
+    env set set_bootcmd_dtb 'env set bootcmd_dtb "true"'
+    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \"\\${fdt_overlays}\"; do env set fitconf_fdt_overlays \"\\"\\${fitconf_fdt_overlays}#conf@\\${overlay_file}\\"\"; env set overlay_file; done; true"'
+    env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && bootm ${ramdisk_addr_r}#conf@\${fdtfile}\${fitconf_fdt_overlays}'
+else
+    env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
+    env set set_bootcmd_dtb 'env set bootcmd_dtb "echo Loading DeviceTree: \\${rootfs_boot_dir}/\\${fdtfile}; ${load_cmd} \\${fdt_addr_r} \\${rootfs_boot_dir}/\\${fdtfile}"'
+    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \\${fdt_overlays}; do echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
+    env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}'
+fi
+
+# Set static commands
+if test ${root_devtype} = "nfs-dhcp"; then
+    env set rootfsargs_set 'env set rootfsargs "root=/dev/nfs ip=dhcp nfsroot=${rootpath}"'
+else
+    if test ${root_devtype} = "nfs-static"; then
+        env set rootfsargs_set 'env set rootfsargs "root=/dev/nfs nfsroot=${serverip}:${rootpath}"'
+    else
+        env set uuid_set 'part uuid ${root_devtype} ${root_devnum}:${root_part} uuid'
+        env set rootfsargs_set 'run uuid_set && env set rootfsargs root=PARTUUID=${uuid} ro rootwait'
+    fi
+fi
+
+env set bootcmd_args 'run rootfsargs_set && env set bootargs ${defargs} ${rootfsargs} ${setupargs} ${vidargs} ${tdxargs}'
+if test ${skip_fdt_overlays} != 1; then
+    env set bootcmd_overlays 'run load_overlays_file && run fdt_resize && run apply_overlays'
+else
+    env set bootcmd_overlays true
+fi
+env set bootcmd_prepare 'run set_bootcmd_kernel; run set_bootcmd_dtb; run set_load_overlays_file; run set_apply_overlays'
+env set bootcmd_run 'run m4boot; run bootcmd_dtb && run bootcmd_overlays && run bootcmd_args && run bootcmd_kernel && run bootcmd_unzip && run bootcmd_boot; echo "Booting from ${devtype} failed!" && false'
+
+run bootcmd_prepare
+while true; do
+    echo "Trying to boot from ${devtype} partition: ${root_part}"
+    run bootcmd_run
+
+    # Boot failed, switch partitions and try again
+    if test ${root_part} = 2; then
+        env set root_part 3
+    else
+        env set root_part 2
+    fi
+    env save
+done

--- a/layers/meta-opentrons/recipes-bsp/u-boot/files/boot.cmd.in
+++ b/layers/meta-opentrons/recipes-bsp/u-boot/files/boot.cmd.in
@@ -5,13 +5,6 @@
 # - Boot the loaded kernel from the rootfs
 # - If boot fails, switch the root_part env var (2-3) and retry boot
 #
-# Common flags:
-# - Boot from rootfs: boot_from_rootfs := {1, 0}
-#   1 - loads the kernel + dtb + overlays from the active rootfs as determined by root_part env. [DEFAULT]
-#   0 - loads the kernel + dtb + overlays from the boot partition.
-# - Boot files: rootfs_boot_dir := {"/boot"}
-#   "/boot" - directory in the rootfs to look for the kernel + dtb + overlays
-
 # SPDX-License-Identifier: GPL-2.0+ OR MIT
 #
 # Copyright 2020 Toradex
@@ -58,21 +51,12 @@ test -n ${boot_devnum} || env set boot_devnum ${devnum}
 test -n ${root_devnum} || env set root_devnum ${devnum}
 test -n ${kernel_image} || env set kernel_image @@KERNEL_IMAGETYPE@@
 test -n ${boot_devtype} || env set boot_devtype ${devtype}
-test -n ${boot_from_rootfs} || env set boot_from_rootfs 1
 test -n ${rootfs_boot_dir} || env set rootfs_boot_dir "/boot"
-test ${boot_from_rootfs} = 0 && env set rootfs_boot_dir ""
 test -n ${overlays_file} || env set overlays_file "${rootfs_boot_dir}/overlays.txt"
 test -n ${overlays_prefix} || env set overlays_prefix "${rootfs_boot_dir}/overlays/"
 
-# load kernel from rootfs or boot partition
-if test "${boot_devtype}" = "mmc"; then
-    if test "${boot_from_rootfs}" = 1; then
-        env set load_cmd 'ext4load ${boot_devtype} ${root_devnum}:${root_part}'
-    else
-        env set load_cmd 'load ${boot_devtype} ${boot_devnum}:${boot_part}'
-    fi
-fi
-
+# load kernel + dtb(s) + overlays from rootfs
+test ${boot_devtype} = "mmc" && env set load_cmd 'ext4load ${boot_devtype} ${root_devnum}:${root_part}'
 test ${boot_devtype} = "usb" && env set load_cmd 'load ${boot_devtype} ${boot_devnum}:${boot_part}'
 test ${boot_devtype} = "tftp" && env set load_cmd 'tftp'
 test ${boot_devtype} = "dhcp" && env set load_cmd 'dhcp'

--- a/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://boot.cmd.in"
+

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -31,6 +31,10 @@ IMAGE_INSTALL += " \
     timestamp-service \
     networkmanager crda \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \
+    weston-xwayland weston weston-init imx-gpu-viv \
+    robot-app-wayland-launch robot-app \
+    opentrons-robot-server opentrons-update-server \
+    python3 python3-misc python3-modules \
  "
 
 ROBOT_TYPE = "OT-3 Standard"

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -31,10 +31,6 @@ IMAGE_INSTALL += " \
     timestamp-service \
     networkmanager crda \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \
-    weston-xwayland weston weston-init imx-gpu-viv \
-    robot-app-wayland-launch robot-app \
-    opentrons-robot-server opentrons-update-server \
-    python3 python3-misc python3-modules \
  "
 
 ROBOT_TYPE = "OT-3 Standard"
@@ -86,8 +82,8 @@ python do_create_opentrons_manifest() {
 }
 ROOTFS_PREPROCESS_COMMAND += "do_create_opentrons_manifest; "
 
-# add the rootfs version to the welcome banner
-do_add_rootfs_version() {
+# changes we might want to make to the rootfs
+do_make_rootfs_changes() {
     printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) \\\n \\\l\n" > ${IMAGE_ROOTFS}/etc/issue
     printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) %%h\n" > ${IMAGE_ROOTFS}/etc/issue.net
     printf "${IMAGE_NAME}\n\n" >> ${IMAGE_ROOTFS}/etc/issue
@@ -101,10 +97,17 @@ do_add_rootfs_version() {
     printf "PRETTY_HOSTNAME=opentrons\n" > ${IMAGE_ROOTFS}/etc/machine-info
     printf "DEPLOYMENT=development\n" >> ${IMAGE_ROOTFS}/etc/machine-info
 
+    # copy the boot files to the /boot dir
+    rsync -aL --chown=root:root  ${DEPLOY_DIR_IMAGE}/Image.gz ${IMAGE_ROOTFS}/boot/
+    rsync -aL --chown=root:root  ${DEPLOY_DIR_IMAGE}/boot.scr* ${IMAGE_ROOTFS}/boot/boot.scr
+    rsync -aL --chown=root:root  ${DEPLOY_DIR_IMAGE}/overlays* ${IMAGE_ROOTFS}/boot/
+    rsync -aL --chown=root:root  ${DEPLOY_DIR_IMAGE}/imx8mm-verdin*dev.dtb ${IMAGE_ROOTFS}/boot/
+    rsync -aL --chown=root:root  ${DEPLOY_DIR_IMAGE}/imx8mm-verdin*dahlia.dtb ${IMAGE_ROOTFS}/boot/
+
     # cleanup
     rm -rf ${IMAGE_ROOTFS}/opentrons_versions
 }
-ROOTFS_POSTPROCESS_COMMAND += "do_add_rootfs_version; "
+ROOTFS_POSTPROCESS_COMMAND += "do_make_rootfs_changes; "
 
 fakeroot do_create_filesystem() {
     # create the userfs tree


### PR DESCRIPTION
[RCORE-395](https://opentrons.atlassian.net/browse/RCORE-395)

# Overview
We have an A/B update mechanism in place, so we should take advantage of that and enable kernel + DTB + overlay updates by hosting them in the rootfs instead of the boot partition. This way they can be updated with a rootfs update and we don't end up like the OT2 where we can't (safely) update to a newer version when the kernel + device tree are out of date.

# Changes
- Load kernel + dtb + overlays from rootfs instead of boot partition
- switch between rootfs partitions 2-3 if boot fails