### PR TITLE
recipes-robot/nginx: remove nginx request size limit for /protocols endpoint

### DIFF
--- a/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
+++ b/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
@@ -33,6 +33,18 @@ http {
             proxy_pass               http://unix:/run/aiohttp.sock;
         }
 
+        location /protocols {
+            proxy_http_version       1.1;
+            proxy_read_timeout       1h;
+            proxy_pass               http://unix:/run/aiohttp.sock;
+
+            # Proxying these hop-by-hop headers is necessary for WebSockets.
+            proxy_set_header         Upgrade $http_upgrade;
+            proxy_set_header         Connection "upgrade";
+            # need for uploading large protocols
+            client_max_body_size     0;
+        }
+
         location /server {
             proxy_http_version       1.1;
             proxy_read_timeout       1h;


### PR DESCRIPTION
Valid protocols larger than 2M were failing because Nginx was configured to max request size of 2M so remove the max request size for the /protocols endpoint so we don't run into this in the future.