### PR TITLE
recipes-core/base-files/fstab: Change rootfs to read-only in fstab

### DIFF
--- a/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
+++ b/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
@@ -1,4 +1,4 @@
-/dev/root            /                    auto       defaults              1  1
+/dev/root            /                    auto       ro              0  0
 proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
@@ -12,6 +12,5 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 /userfs/home             /home                 none       defaults,bind         0  0
 /userfs/data             /data                 none       defaults,bind         0  0
 /userfs/var              /var                  none       defaults,bind         0  0
-/userfs/etc/hosts        /etc/hosts            none       defaults,bind,nofail  0  0
 /userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail  0  0
 /userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail  0  0

--- a/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,0 +1,7 @@
+do_install_append() {
+   # create a symlink to store rsa host keys in read-write /var/lib/dropbear dir.
+   install -d ${D}/var/lib/dropbear
+   rm -rf ${D}/${sysconfdir}/dropbear
+   ln -sf /var/lib/dropbear ${D}/${sysconfdir}/dropbear
+
+}


### PR DESCRIPTION
**Closes:** [RCORE-178](https://opentrons.atlassian.net/browse/RCORE-178)

**Overview:**
We only want parts of the system to be read-write like /userfs, /var, etc for everything else we want read-only. 

**Changelog:**
- change root mount option to ro (read-only)
- create a symlink for dropbear host rsa key-file /etc/dropbear -> /var/lib/dropbear