### PR TITLE
recipes-kernel/ch341ser: add ch341ser usb driver kernel module support

### DIFF
--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -28,8 +28,7 @@ IMAGE_INSTALL += " \
     udev-extraconf \
     v4l-utils \
     bash coreutils makedevs mime-support util-linux \
-    timestamp-service \
-    networkmanager crda \
+    timestamp-service networkmanager crda ch341ser \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \
     weston-xwayland weston weston-init imx-gpu-viv \
     robot-app-wayland-launch robot-app \

--- a/layers/meta-opentrons/recipes-kernel/ch341ser/ch341ser_git.bb
+++ b/layers/meta-opentrons/recipes-kernel/ch341ser/ch341ser_git.bb
@@ -1,0 +1,15 @@
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+SRC_URI = "git://github.com/juliagoda/CH341SER.git;protocol=https"
+
+# Modify these as desired
+PV = "1.0+git${SRCPV}"
+SRCREV = "7a8278fd48f884f3ca4b4dd738f3d73eef07d344"
+
+S = "${WORKDIR}/git"
+
+inherit module
+
+EXTRA_OEMAKE_append_task-install = " -C ${STAGING_KERNEL_DIR} M=${S}"
+EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_DIR}"


### PR DESCRIPTION
# Overview:

Adds kernel driver for [CH341SER](https://github.com/juliagoda/CH341SER) serial to USB module.


# Todo:

- [x] Make sure this works on the actual OT3 hardware.
- [x] Validate with Carlos Fernandez
