### PR TITLE
build: fix permission issue causing python_build_util.py to fail in Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ RUN mkdir -p /volumes/oe-core && mkdir -p /volumes/cache
 USER $USER_NAME
 
 RUN git config --global user.name "Opentrons" && \
-    git config --global user.email engineering@opentrons.com
+    git config --global user.email engineering@opentrons.com && \
+    git config --global --add safe.directory /volumes/opentrons
 
 # Create the directory structure for the Yocto build in the container. The lowest two directory
 # levels must be the same as on the host.


### PR DESCRIPTION
# Overview:

Builds are failing because of an exception caused bu using python_build_util.py when attempting to run a git command as a subprocess. This was due to /volumes/opentrons not having the right permissions, so lets just label /volumes/opentrons as a safe.directory in the git config.

# Changes:

- set /volumes/opentrons as a safe.directory in the git config of the Dockerfile