### PR TITLE
fix(recipes-robot): we should not set proxy headers for the /protocols endpoint in nginx conf

### DIFF
--- a/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
+++ b/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
@@ -38,9 +38,6 @@ http {
             proxy_read_timeout       1h;
             proxy_pass               http://unix:/run/aiohttp.sock;
 
-            # Proxying these hop-by-hop headers is necessary for WebSockets.
-            proxy_set_header         Upgrade $http_upgrade;
-            proxy_set_header         Connection "upgrade";
             # need for uploading large protocols
             client_max_body_size     0;
         }


### PR DESCRIPTION
## Overview

See RSS-166 for further issue on the bug found. Essentially, this change made the `/protocols` endpoint unusable. I am still debugging a separate issue that's popping up after this conf change so I will keep this PR open until I can find the root cause.