### PR TITLE
recipes-robot/opentrons-mcu-firmware: add filepath from filename provided by subsystem_versions.py 

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -54,7 +54,9 @@ python do_create_manifest(){
 
     # add the filepath
     for subsystem in manifest['subsystems']:
-        filepath = "%s/%s.hex" % (d.getVar("FIRMWARE_DIR"), subsystem)
+	# TODO (BA, 02/1/2023): We will need a more flexible solution for filepath, for now just use rev1.
+	filename = subsystem.get('filename')
+        filepath = "%s/%s" % (d.getVar("FIRMWARE_DIR"), filepath)
         manifest['subsystems'][subsystem].update({
             "filepath": filepath
         })

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -53,11 +53,12 @@ python do_create_manifest(){
     }
 
     # add the filepath
+    firmware_path = d.getVar("FIRMWARE_DIR")
     for subsystem, update_info in manifest['subsystems'].items():
         for rev, filename in update_info.get('files_by_revision').items():
             manifest['subsystems'][subsystem]['files_by_revision'].update({
-                rev: f"d.getVar("FIRMWARE_DIR")/{filename}"
-        })
+                rev: f"{firmware_path}/{filename}"
+            })
 
     # save manifest file to disk
     manifest_file = "%s/opentrons-firmware.json" % (d.getVar("S"))

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -53,9 +53,9 @@ python do_create_manifest(){
     }
 
     # add the filepath
-    for subsystem in manifest['subsystems']:
+    for subsystem, update_info in manifest['subsystems'].items():
 	# remove filename key and add filepath key instead
-        filepath = "%s/%s" % (d.getVar("FIRMWARE_DIR"), subsystem.pop('filename'))
+        filepath = "%s/%s" % (d.getVar("FIRMWARE_DIR"), update_info.pop('filename'))
         manifest['subsystems'][subsystem].update({
             "filepath": filepath
         })

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -71,13 +71,13 @@ python do_create_manifest(){
 INSANE_SKIP_${PN} += "arch"
 
 FILES_${PN} += "${libdir}/firmware \
-                ${libdir}/firmware/head_rev1.hex \
-                ${libdir}/firmware/gantry_x-rev1.hex \
-                ${libdir}/firmware/gantry_y-rev1.hex \
+                ${libdir}/firmware/head-rev1.hex \
+                ${libdir}/firmware/gantry-x-rev1.hex \
+                ${libdir}/firmware/gantry-y-rev1.hex \
                 ${libdir}/firmware/gripper-rev1.hex \
-                ${libdir}/firmware/pipettes_single-rev1.hex \
-                ${libdir}/firmware/pipettes_multi-rev1.hex \
-                ${libdir}/firmware/pipettes_96-rev1.hex \
+                ${libdir}/firmware/pipettes-single-rev1.hex \
+                ${libdir}/firmware/pipettes-multi-rev1.hex \
+                ${libdir}/firmware/pipettes-96-rev1.hex \
                 ${libdir}/firmware/opentrons-firmware.json"
 
 addtask do_create_manifest after do_compile before do_install

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -54,9 +54,8 @@ python do_create_manifest(){
 
     # add the filepath
     for subsystem in manifest['subsystems']:
-	# TODO (BA, 02/1/2023): We will need a more flexible solution for filepath, for now just use rev1.
-	filename = subsystem.get('filename')
-        filepath = "%s/%s" % (d.getVar("FIRMWARE_DIR"), filepath)
+	# remove filename key and add filepath key instead
+        filepath = "%s/%s" % (d.getVar("FIRMWARE_DIR"), subsystem.pop('filename'))
         manifest['subsystems'][subsystem].update({
             "filepath": filepath
         })
@@ -72,13 +71,13 @@ python do_create_manifest(){
 INSANE_SKIP_${PN} += "arch"
 
 FILES_${PN} += "${libdir}/firmware \
-                ${libdir}/firmware/head-rev1.hex \
-                ${libdir}/firmware/gantry-x-rev1.hex \
-                ${libdir}/firmware/gantry-y-rev1.hex \
+                ${libdir}/firmware/head_rev1.hex \
+                ${libdir}/firmware/gantry_x-rev1.hex \
+                ${libdir}/firmware/gantry_y-rev1.hex \
                 ${libdir}/firmware/gripper-rev1.hex \
-                ${libdir}/firmware/pipettes-single-rev1.hex \
-                ${libdir}/firmware/pipettes-multi-rev1.hex \
-                ${libdir}/firmware/pipettes-96-rev1.hex \
+                ${libdir}/firmware/pipettes_single-rev1.hex \
+                ${libdir}/firmware/pipettes_multi-rev1.hex \
+                ${libdir}/firmware/pipettes_96-rev1.hex \
                 ${libdir}/firmware/opentrons-firmware.json"
 
 addtask do_create_manifest after do_compile before do_install

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -54,10 +54,9 @@ python do_create_manifest(){
 
     # add the filepath
     for subsystem, update_info in manifest['subsystems'].items():
-	# remove filename key and add filepath key instead
-        filepath = "%s/%s" % (d.getVar("FIRMWARE_DIR"), update_info.pop('filename'))
-        manifest['subsystems'][subsystem].update({
-            "filepath": filepath
+        for rev, filename in update_info.get('files_by_revision').items():
+            manifest['subsystems'][subsystem]['files_by_revision'].update({
+                rev: f"d.getVar("FIRMWARE_DIR")/{filename}"
         })
 
     # save manifest file to disk


### PR DESCRIPTION
- fix an issue with wrong filenames
- Dont assume the names of the binary files, instead, have ot3-firmware repo's subsystem_versions.py script deal with that so oe-core can just deal with placing the files in the correct location.
- Change structure to `{"subsystem": {"branch": branch, "version": version, "shortsha": shortsha, "files_by_revision": {"rev1": filepath}}`