### PR TITLE
opentrons-mcu-firmware: install all revisions

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -13,12 +13,15 @@ DEPENDS += " cmake-native"
 
 do_configure(){
     cd ${S}/
+    bbnote "cmake --preset=cross-no-directory-reqs -B ${B}/build-cross --install-prefix=${B}/dist ."
     cmake --preset=cross-no-directory-reqs -B ${B}/build-cross --install-prefix=${B}/dist .
+
 }
 
 do_compile(){
     cd ${S}/
-    cmake --build --preset=all-application-firmware
+
+    cmake --build ${B}/build-cross --target firmware-applications
     cmake --install ${B}/build-cross --component Applications
     # get the submodule versions to be used when creating the opentrons-firmware.json file
     python3 ${S}/scripts/subsystem_versions.py --hexfile=${B}/dist/applications --output ${B}/dist/applications/opentrons-firmware.json

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -5,8 +5,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 inherit externalsrc pkgconfig cmake
 
 FIRMWARE_DIR="${libdir}/firmware"
-#S = "${WORKDIR}"
-#B = "${S}/build"
 
 EXTERNALSRC = "${@os.path.abspath(os.path.join("${TOPDIR}", os.pardir, os.pardir, "ot3-firmware"))}"
 DEPENDS += " cmake-native"

--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -24,7 +24,7 @@ do_compile(){
     cmake --build ${B}/build-cross --target firmware-applications
     cmake --install ${B}/build-cross --component Applications
     # get the submodule versions to be used when creating the opentrons-firmware.json file
-    python3 ${S}/scripts/subsystem_versions.py --hexfile=${B}/dist/applications --output ${B}/dist/applications/opentrons-firmware.json
+    python3 ${S}/scripts/subsystem_versions.py --hex-dir=${B}/dist/applications ${B}/dist/applications/subsystem_versions.json
 }
 
 do_install(){


### PR DESCRIPTION
https://github.com/Opentrons/ot3-firmware/pull/567 provides firmware for all electrical revisions, built and distributed to an install area and gathered by `subsystem_versions.json`. This PR takes those firmwares and makes sure they get properly gathered - using the cmake install mechanism added by previous ot3-firmware PRs - and installed, and wrapped up in opentrons-firmware.json.

This is safe to do without corresponding python-side changes because ot3-firmware establishes revision aliases for `rev1`, so we can have the files present before we get around to actually installing them.

Closes RET-1322