### PR TITLE
set max unused protocols on robot server to 20

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -11,6 +11,7 @@ Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
 Environment=OT_ROBOT_SERVER_persistence_directory=%S/opentrons-robot-server
+Environment=OT_ROBOT_SERVER_maximum_unused_protocols=20
 Restart=on-failure
 TimeoutStartSec=3min
 After=opentrons-ot3-canbus


### PR DESCRIPTION
# Overview

https://github.com/Opentrons/opentrons/pull/12094 allows us to set the max unused number of protocols the robot server will store via an env variable. This PR actually sets that env variable for the Flex without affecting OT-2 behavior

closes https://opentrons.atlassian.net/browse/RCORE-613

# Changes

- Set max unused protocols on robot server to 20

# Risk Assessment

- Low, just an env variable that has a fallback inside the robot server

[RCORE-287]: https://opentrons.atlassian.net/browse/RCORE-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ