### PR TITLE
layers/meta-opentrons: add OT user environment

### DIFF
--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -50,6 +50,7 @@ IMAGE_INSTALL += " \
     python3 python3-misc python3-modules \
     opentrons-usb-bridge opentrons-system-server \
     opentrons-mcu-firmware \
+    opentrons-user-environment \
  "
 
 # We do NOT want the toradex libusbgx packages that autoconfigure the OTG USB

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/ot-environ.sh
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/ot-environ.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+export RUNNING_ON_VERDIN=1
+export OT_API_FF_enableOT3HardwareController="true"

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/ot-environ.sh
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/ot-environ.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 export RUNNING_ON_VERDIN=1
 export OT_API_FF_enableOT3HardwareController="true"
+export PYTHONPATH=$PYTHONPATH:/opt/opentrons-robot-server

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -8,7 +8,7 @@ SRC_URI = "file://ot-environ.sh"
 
 do_install() {
       install -d ${D}/${sysconfdir}/profile.d/
-      install -m 0755 ${WORKDIR}/ot-environ.sh ${sysconfdir}/profile.d/ot-environ.sh
+      install -m 0755 ${WORKDIR}/ot-environ.sh ${D}/${sysconfdir}/profile.d/ot-environ.sh
 }
 
 FILES_${PN} += "${sysconfdir}/profile.d/ot-environ.sh \

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "installs defaults for the remote shell user environment"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-SRC_URI = "file://opentrons-environment.sh"
+SRC_URI = "file://ot-environ.sh"
 
 do_install() {
       install -d ${D}/${sysconfdir}/profile.d/

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -8,8 +8,8 @@ SRC_URI = "file://ot-environ.sh"
 
 do_install() {
       install -d ${D}/${sysconfdir}/profile.d/
-      install -m 0755 ${WORKDIR}/ot-environ.sh ${sysconfdir}/init.d/ot-environ.sh
+      install -m 0755 ${WORKDIR}/ot-environ.sh ${sysconfdir}/profile.d/ot-environ.sh
 }
 
-FILES_${PN} += "${sysconfdir}/init.d/ot-environ.sh \
+FILES_${PN} += "${sysconfdir}/profile.d/ot-environ.sh \
             "

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -1,0 +1,15 @@
+# Copyright (C) 2023 Seth Foster <seth@opentrons.com>
+# Released under the MIT License (see COPYING.MIT for the terms)
+DESCRIPTION = "installs defaults for the remote shell user environment"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://opentrons-environment.sh"
+
+do_install() {
+      install -d ${D}/${sysconfdir}/profile.d/
+      install -m 0755 ${WORKDIR}/ot-environ.sh ${sysconfdir}/init.d/ot-environ.sh
+}
+
+FILES_${PN} += "${sysconfdir}/init.d/ot-environ.sh \
+            "


### PR DESCRIPTION
There are a couple environment variables that need to be defined for our software to work. They're defined in systemd units for things that are run automatically, but it's helpful to also have them present in user shells for running scripts. Let's make them present there.