### PR TITLE
recipes-images/opentrons-ot3-image: add dfu-util to support rear panel board updates.

### DIFF
--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -40,7 +40,7 @@ IMAGE_INSTALL += " \
     packagegroup-tdx-graphical \
     packagegroup-fsl-isp \
     udev-extraconf \
-    v4l-utils \
+    v4l-utils dfu-util \
     bash coreutils makedevs mime-support util-linux \
     timestamp-service networkmanager crda ch341ser \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \


### PR DESCRIPTION
# Test Plan

- [x] Make sure **dfu-util** cli command works on OT3