### PR TITLE
recipes-images/opentrons-ot3-image: Increase rootfs size to 2GB + check max rootfs size when building.

### DIFF
--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -65,7 +65,7 @@ IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
 USERFS_DIR = "${WORKDIR}/userfs"
 USERFS_OUTPUT = "${DEPLOY_DIR_IMAGE}/userfs.ext4"
 # max rootfs partition size in mb
-MAX_SYSTEMFS_SIZE = "1536"
+MAX_SYSTEMFS_SIZE = "2048"
 
 # create the opentrons ot3 manifest (VERSION.json) file
 python do_create_opentrons_manifest() {
@@ -149,6 +149,16 @@ do_make_rootfs_changes() {
 ROOTFS_POSTPROCESS_COMMAND += "do_make_rootfs_changes; "
 
 fakeroot do_create_filesystem() {
+    # check that the size of the rootfs is not greater than the max systemfs partition
+    systemfs=${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.ext4.xz
+    systemfs_size_raw=$(xz -l ${systemfs} | awk 'FNR == 2 {print $5}' | tr -d ',')
+    systemfs_size_mb=${systemfs_size_raw%.*}
+    rootfs_overflow=`expr ${systemfs_size_mb} \> ${MAX_SYSTEMFS_SIZE}` || echo 0
+    if [ ${rootfs_overflow} = 1 ]; then
+        bberror "CRITICAL: Rootfs size ${systemfs_size_mb} is greater than max allowed ${MAX_SYSTEMFS_SIZE}!."
+        exit 1
+    fi
+
     # create the userfs tree
     rsync -aH --chown=root:root ${IMAGE_ROOTFS}/home ${USERFS_DIR}/
     rsync -aH --chown=root:root ${IMAGE_ROOTFS}/var ${USERFS_DIR}/
@@ -262,7 +272,7 @@ fakeroot do_create_tezi_ot3() {
 # create the opentrons ot3 image
 do_create_opentrons_ot3() {
     cd ${DEPLOY_DIR_IMAGE}/
-    cp opentrons-ot3-image-verdin-imx8mm.ext4.xz systemfs.xz
+    ln opentrons-ot3-image-verdin-imx8mm.ext4.xz systemfs.xz
 
     # compute the sha256sum
     sha256sum systemfs.xz | cut -d " " -f 1 > systemfs.xz.sha256


### PR DESCRIPTION
# Overview

We have a lot of stuff on the OT3, and the 1.5GB of space we have for system services has already been used up. However, the builds were not taking this into account and were generating images that were bigger than the partition size they were to be installed in. The system-server also does not check if the update size fits in the partition it's writing to, which caused critical files to be overwritten, and when the system restarts that would brick it. 

So first let's increase the size of the partition to 2GB, this won't get us very far but it will at least get us moving.
Secondly, we need not produce images that are larger than the partition size so let's take that into account and bail.
Ideally, we can reduce the size of our packages, but let's stop the bleeding first.

# Changes
- Increase systemfs size to 2GB
- Don't build an image if the systemfs (rootfs) is too large for the systemfs partition.

# Test Plan

- [x] Make sure we dont build an image if the size is too large
- [x] Make sure generated image is now 2GB
- [x] Flash on OT3 and make sure we can boot