### PR TITLE
opentrons-mcu-firmware: allow .bin for rear panel

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -37,5 +37,5 @@ FILES_${PN} += "${libdir}/firmware/head-*.hex \
                 ${libdir}/firmware/gantry-*.hex \
                 ${libdir}/firmware/gripper-*.hex \
                 ${libdir}/firmware/pipettes-*.hex \
-                ${libdir}/firmware/rear-panel-*.hex \
+                ${libdir}/firmware/rear-panel-*.bin \
                 ${libdir}/firmware/opentrons-firmware.json"


### PR DESCRIPTION
The rear panel system recently changed to have its applications use .bin instead of .hex for the files; this makes OE complain because we told it to expect us to install only .hex. Add the rear-panel binaries to FILES.