### PR TITLE
recipes-robot/nginx: add system server carveout to nginx.conf

### DIFF
--- a/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
+++ b/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
@@ -50,5 +50,21 @@ http {
             proxy_request_buffering  off;
             client_max_body_size     0;
         }
+
+        location /system {
+            proxy_http_version       1.1;
+            proxy_read_timeout       1h;
+            proxy_pass               http://127.0.0.1:32950;
+        }
+
+        # The /system/time endpoints live in the robot server, and thus
+        # the configuration here has to match the / config
+        location /system/time {
+            proxy_http_version       1.1;
+            proxy_set_header         Upgrade $http_upgrade;
+            proxy_set_header         Connection $connection_upgrade;
+            proxy_read_timeout       1h;
+            proxy_pass               http://unix:/run/aiohttp.sock;
+        }
     }
 }

--- a/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
+++ b/layers/meta-opentrons/recipes-robot/nginx/files/nginx.conf
@@ -31,6 +31,23 @@ http {
             proxy_set_header         Connection $connection_upgrade;
             proxy_read_timeout       1h;
             proxy_pass               http://unix:/run/aiohttp.sock;
+
+            # The /system/time endpoints live in the robot server, and thus
+            # the configuration here has to match the / config
+            location /system/time { 
+                proxy_http_version       1.1;
+                proxy_read_timeout       1h;
+                proxy_pass               http://unix:/run/aiohttp.sock;
+
+            }
+
+            # /system must be defined as a nested child of /, otherwise it will
+            # conflict with matches to /system/time.
+            location /system {
+                proxy_http_version       1.1;
+                proxy_read_timeout       1h;
+                proxy_pass               http://127.0.0.1:32950;
+            }
         }
 
         location /protocols {
@@ -49,22 +66,6 @@ http {
             proxy_pass               http://127.0.0.1:34000;
             proxy_request_buffering  off;
             client_max_body_size     0;
-        }
-
-        location /system {
-            proxy_http_version       1.1;
-            proxy_read_timeout       1h;
-            proxy_pass               http://127.0.0.1:32950;
-        }
-
-        # The /system/time endpoints live in the robot server, and thus
-        # the configuration here has to match the / config
-        location /system/time {
-            proxy_http_version       1.1;
-            proxy_set_header         Upgrade $http_upgrade;
-            proxy_set_header         Connection $connection_upgrade;
-            proxy_read_timeout       1h;
-            proxy_pass               http://unix:/run/aiohttp.sock;
         }
     }
 }


### PR DESCRIPTION
This PR adds configuration to NGINX to allow external access to the system server.

Also adds an explicit config to route `/system/time` to the robot server, as that endpoint is not ported to the system server yet.

Tested by uploading the edited `nginx.conf` to a robot and running `nginx -s reload`, and also uploading the system server changes from https://github.com/Opentrons/opentrons/pull/12278. 
* I was able to go to `{robot_url}:31950/system/docs` and interact with the endpoints on the system server without issue. 
* I was also about to go to `{robot_url}:31950/docs` and interact with `GET /system/time` without issue.