### PR TITLE
opentrons-robot-app: allow remote devtools

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.service
@@ -1,0 +1,10 @@
+[Unit]
+Requires=opentrons-robot-app.service
+After=opentrons-robot-app.service
+Requires=opentrons-robot-app-devtools.socket
+After=opentrons-robot-app-devtools.socket
+JoinsNamespaceOf=opentrons-robot-app.service
+
+[Service]
+ExecStart=/lib/systemd/systemd-socket-proxyd 127.0.0.1:9222
+PrivateTmp=yes

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.service
@@ -3,7 +3,6 @@ Requires=opentrons-robot-app.service
 After=opentrons-robot-app.service
 Requires=opentrons-robot-app-devtools.socket
 After=opentrons-robot-app-devtools.socket
-JoinsNamespaceOf=opentrons-robot-app.service
 
 [Service]
 ExecStart=/lib/systemd/systemd-socket-proxyd 127.0.0.1:9222

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.socket
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream=9222
+
+[Install]
+WantedBy=sockets.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.socket
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.socket
@@ -1,5 +1,5 @@
 [Socket]
-ListenStream=9222
+ListenStream=9223
 
 [Install]
 WantedBy=sockets.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/robot-app-wayland-launch_1.0.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/robot-app-wayland-launch_1.0.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 inherit allarch systemd
 
-RDEPENDS_${PN}_append = "weston-init opentrons-robot-app"
+RDEPENDS_${PN}_append = "weston-init opentrons-robot-app systemd-extra-utils"
 
 S = "${WORKDIR}"
 
@@ -14,13 +14,15 @@ SRC_URI = " \
     file://opentrons-robot-app.sh.in \
     file://setup-tps65154.sh \
     file://configure-screen-power.service \
+    file://opentrons-robot-app-devtools.service \
+    file://opentrons-robot-app-devtools.socket \
 "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 APPLICATION_ENVIRONMENT := '\"DISPLAY=\:0\:0\" \"XDG_SESSION_TYPE=wayland\" \"XDG_SESSION_DESKTOP=kiosk\" \"PYTHONPATH=/opt/opentrons-robot-server\"'
 
-WAYLAND_APPLICATION := "/opt/opentrons-app/opentrons --discovery.candidates=localhost --discovery.ipFilter=\"127.0.0.1\" --isOnDevice=1 --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=wayland --in-process-gpu --python.pathToPythonOverride=/usr/bin/python3"
+WAYLAND_APPLICATION := "/opt/opentrons-app/opentrons --remote-debugging-port=9222 --discovery.candidates=localhost --discovery.ipFilter=\"127.0.0.1\" --isOnDevice=1 --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=wayland --in-process-gpu --python.pathToPythonOverride=/usr/bin/python3"
 
 do_compile () {
     sed -e "s:@@wayland-application@@:${WAYLAND_APPLICATION}:" -e "s:@@initial-path@@:${INITIAL_PATH}:" opentrons-robot-app.sh.in > opentrons-robot-app.sh
@@ -34,7 +36,10 @@ do_install () {
 
     install -m 0644 ${WORKDIR}/configure-screen-power.service ${D}${systemd_unitdir}/system
     install -m 0755 ${WORKDIR}/setup-tps65154.sh ${D}/${bindir}
+
+    install -m 0644 ${WORKDIR}/opentrons-robot-app-devtools.socket ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/opentrons-robot-app-devtools.service ${D}${systemd_unitdir}/system/
 }
 
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE_${PN} = "opentrons-robot-app.service configure-screen-power.service"
+SYSTEMD_SERVICE_${PN} = "opentrons-robot-app.service configure-screen-power.service opentrons-robot-app-devtools.service opentrons-robot-app-devtools.socket"


### PR DESCRIPTION
Chrome has a [remote devtools protocol](https://chromedevtools.github.io/devtools-protocol/) that you can use to separate where you run devtools from where you're running content - pretty similar to a remote debugging interface like `gdb-server` or the mac tandem kernel debugger or whatever. That's really convenient because then we don't have to try and use the devtools on the little touchscreen.

Since electron is chrome, it's built into electron, and you can tell electron to listen on a port. The problem is, electron will only listen on that port _to localhost_, and the entire point of this exercise is to make this accessible off of localhost.

As always, systemd has a solution for this: [systemd-socket-proxyd](https://manpages.ubuntu.com/manpages/bionic/man8/systemd-socket-proxyd.8.html) is a socket proxy (works on tcp and udp, used here for tcp) that can be activated by a [systemd socket unit](https://manpages.debian.org/testing/systemd/systemd.socket.5.en.html) that listens on a port. They can't use the same port without more extensive configuration (read: a bunch of bindings to come up and down as interfaces do, since binding to 0.0.0.0:nnnn conflicts with binding to 127.0.0.1:nnnn), so we can expose 9223 for an internal connection to 9222, and now you can point a chrome at it and get devtools! hooray!