### PR TITLE
.github: fix failure looking up tags

### DIFF
--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -20,7 +20,11 @@ export type AttemptableRefs = Map<Repo, AttemptableRef[]>
 export type OutputRefs = Map<Repo, Ref>
 
 function mainRefFor(input: Repo): Branch {
-  return { monorepo: 'refs/heads/edge', 'oe-core': 'refs/heads/main', 'ot3-firmware': 'refs/heads/main' }[input]
+  return {
+    monorepo: 'refs/heads/edge',
+    'oe-core': 'refs/heads/main',
+    'ot3-firmware': 'refs/heads/main',
+  }[input]
 }
 
 export function restAPICompliantRef(input: Ref): string {
@@ -170,7 +174,7 @@ async function resolveRefs(toAttempt: AttemptableRefs): Promise<OutputRefs> {
           }
           const availableRefs = value.data.map(refObj => refObj.ref)
           core.info(`refs on ${repoName} matching ${ref}: ${availableRefs}`)
-          return availableRefs.includes(ref) ? ref : null
+          return availableRefs.includes(correctRef) ? correctRef : null
         })
     }
 

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -9750,7 +9750,11 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 const orderedRepos = ['monorepo', 'oe-core', 'ot3-firmware'];
 function mainRefFor(input) {
-    return { monorepo: 'refs/heads/edge', 'oe-core': 'refs/heads/main', 'ot3-firmware': 'refs/heads/main' }[input];
+    return {
+        monorepo: 'refs/heads/edge',
+        'oe-core': 'refs/heads/main',
+        'ot3-firmware': 'refs/heads/main',
+    }[input];
 }
 function restAPICompliantRef(input) {
     return input.replace('refs/', '');
@@ -9852,7 +9856,7 @@ function resolveRefs(toAttempt) {
                     }
                     const availableRefs = value.data.map(refObj => refObj.ref);
                     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`refs on ${repoName} matching ${ref}: ${availableRefs}`);
-                    return availableRefs.includes(ref) ? ref : null;
+                    return availableRefs.includes(correctRef) ? correctRef : null;
                 });
             });
             resolved.set(repo, yield Promise.all(refList.map(ref => refResolves(repo, ref))).then(presentRefs => presentRefs.find(maybeRef => maybeRef !== null)));


### PR DESCRIPTION
When we look up the latest tag, we were trying to find the literal ':latest:' in the list of tags we got back from github, which won't ever work. Instead add a tested helper function for that.