### PR TITLE
meta-opentrons: correct version for python servers

### DIFF
--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -182,4 +182,4 @@ do_install () {
 }
 
 
-FILES_${PN} = "${PIPENV_APP_BUNDLE_DIR}/opentrons_versions"
+FILES_${PN} = "${PIPENV_APP_BUNDLE_DIR} opentrons_versions"

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -19,7 +19,7 @@ PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/robot-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-robot-server"
 PIPENV_APP_BUNDLE_USE_GLOBAL = "numpy systemd-python python-can wrapt pyzmq "
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
-PIPENV_APP_BUNDLE_EXTRAS = "./../hardware"
+PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=ot3"
 
 do_compile_append() {
     # dont include scripts

--- a/layers/meta-opentrons/recipes-robot/opentrons-system-server/opentrons-system-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-system-server/opentrons-system-server.bb
@@ -19,7 +19,7 @@ PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/system-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-system-server"
 PIPENV_APP_BUNDLE_USE_GLOBAL = "systemd-python "
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
-PIPENV_APP_BUNDLE_EXTRAS = "./../hardware"
+PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=ot3"
 
 do_compile_append() {
 }

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -23,6 +23,7 @@ PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-update-server"
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRAS = ""
 PIPENV_APP_BUNDLE_USE_GLOBAL = "python3-aiohttp systemd-python"
+PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=ot3"
 
 do_install_append() {
   # create json file to be used in VERSION.json


### PR DESCRIPTION
The robot server wasn't being installed with the correct version, because we weren't able to set the proper environment variable to do so. Add that capability and set it in the build system for all the python servers.

## Testing
- [x] image builds
- [x] `/opt/opentrons-robot-server` has `0.0.2a1` of `opentrons`, `robot-server`, `opentrons_shared_data`, `notify-server`, `opentrons_hardware`
- [x] `/opt/opentrons-system-server` has `0.0.2a1` of `system-server`
- [x] `/opt/opentrons-update-server` has `0.0.2a1` of `otupdate`