### PR TITLE
opentrons-robot-server: use internal release notes

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -32,7 +32,7 @@ do_install_append () {
     # add release notes
     install -d ${D}${sysconfdir}
     # TODO: Make this not the internal release notes at some point
-    install ${S}/api/release-notes-internal.md ${D}${sysconfdir}/release-notes-internal.md
+    install ${S}/api/release-notes-internal.md ${D}${sysconfdir}/release-notes.md
 
     # create json file to be used in VERSION.json
     install -d ${D}/opentrons_versions

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -31,6 +31,7 @@ addtask do_write_systemd_dropfile after do_compile before do_install
 do_install_append () {
     # add release notes
     install -d ${D}${sysconfdir}
+    # TODO: Make this not the internal release notes at some point
     install ${S}/api/release-notes-internal.md ${D}${sysconfdir}/release-notes-internal.md
 
     # create json file to be used in VERSION.json

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -31,7 +31,7 @@ addtask do_write_systemd_dropfile after do_compile before do_install
 do_install_append () {
     # add release notes
     install -d ${D}${sysconfdir}
-    install ${S}/api/release-notes.md ${D}${sysconfdir}/
+    install ${S}/api/release-notes-internal.md ${D}${sysconfdir}/release-notes-internal.md
 
     # create json file to be used in VERSION.json
     install -d ${D}/opentrons_versions


### PR DESCRIPTION
These will be set for internal releases. We'll have to change this before full production release.