### PR TITLE
opentrons-robot-server: store api package version

### DIFF
--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -100,6 +100,7 @@ python do_create_opentrons_manifest() {
     expected_opentrons_versions = ["opentrons-robot-server-version.json", \
                                    "opentrons-update-server-version.json", \
                                    "opentrons-system-server-version.json", \
+                                   "opentrons-api-version.json", \
                                    "opentrons-usb-bridge-version.json"]
 
     opentrons_versions_dir = "%s/opentrons_versions" % d.getVar('STAGING_DIR_HOST')

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -37,6 +37,7 @@ do_install_append () {
     # create json file to be used in VERSION.json
     install -d ${D}/opentrons_versions
     python3 ${S}/scripts/python_build_utils.py robot-server ot3 dump_br_version > ${D}/opentrons_versions/opentrons-robot-server-version.json
+    python3 ${S}/scripts/python_build_utils.py api ot3 dump_br_version > ${D}/opentrons_versions/opentrons-api-version.json
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-robot-server.service ${D}${systemd_system_unitdir}/opentrons-robot-server.service


### PR DESCRIPTION
We were not storing the version of the api package that the robot server relies on. This is used by the update server to respond with the version of the loaded package, and without it we don't get a version there. On the OT-2, this is provided by the separate api package recipe, but we've folded that in to the robot server here so we need to do it in the same recipe.

Closes RQA-577