### PR TITLE
recipes-robot/opentrons-user-environment: add OT_SYSTEM_VERSION environment flag

### DIFF
--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -120,6 +120,12 @@ python do_create_opentrons_manifest() {
     opentrons_json_output = "%s/VERSION.json" % d.getVar('DEPLOY_DIR_IMAGE')
     with open(opentrons_json_output, 'w') as fh:
         json.dump(opentrons_manifest, fh, indent=4)
+
+    # write the system version file
+    ot_system_version = "%s/OT_SYSTEM_VERSION" % d.getVar('DEPLOY_DIR_IMAGE')
+    with open(ot_system_version, 'w'):
+        fh.write(oe_version)
+
 }
 ROOTFS_PREPROCESS_COMMAND += "do_create_opentrons_manifest; "
 
@@ -130,8 +136,9 @@ do_make_rootfs_changes() {
     printf "${IMAGE_NAME}\n\n" >> ${IMAGE_ROOTFS}${sysconfdir}/issue
     printf "${IMAGE_NAME}\n\n" >> ${IMAGE_ROOTFS}${sysconfdir}/issue.net
 
-    # add the VERSION.json file
+    # add the VERSION.json file and OT_SYSTEM_VERSION
     cat ${DEPLOY_DIR_IMAGE}/VERSION.json > ${IMAGE_ROOTFS}${sysconfdir}/VERSION.json
+    cat ${DEPLOY_DIR_IMAGE}/OT_SYSTEM_VERSION ${IMAGE_ROOTFS}${sysconfdir}/OT_SYSTEM_VERSION
     # copy the release notes to the output dir
     cat ${IMAGE_ROOTFS}${sysconfdir}/release-notes.md > ${DEPLOY_DIR_IMAGE}/release-notes.md
 

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/ot-environ.sh
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/ot-environ.sh
@@ -2,3 +2,10 @@
 export RUNNING_ON_VERDIN=1
 export OT_API_FF_enableOT3HardwareController="true"
 export PYTHONPATH=$PYTHONPATH:/opt/opentrons-robot-server
+
+# add OT_SYSTEM_VERSION 
+if [ -f /etc/OT_SYSTEM_VERSION ]; then
+	ot_system_version=$(cat /etc/OT_SYSTEM_VERSION)
+	echo "Setting OT_SYSTEM_VERSION=${ot_system_version}"
+	export OT_SYSTEM_VERSION="${ot_system_version}"
+fi


### PR DESCRIPTION
We need to set the OT_SYSTEM_VERSION environment variable so the `opentrons` module can be imported from jupyter notebook 

* Test on the Flex
* Make sure the `OT_SYSTEM_VERSION` env var is set properly
* Make sure we can import `opentrons` package from jupyter notebook