### PR TITLE
opentrons-robot-server: longer start timeout

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -13,7 +13,7 @@ Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packa
 Environment=OT_ROBOT_SERVER_persistence_directory=%S/opentrons-robot-server
 Environment=OT_ROBOT_SERVER_maximum_unused_protocols=20
 Restart=on-failure
-TimeoutStartSec=3min
+TimeoutStartSec=10min
 After=opentrons-ot3-canbus
 Wants=opentrons-ot3-canbus
 


### PR DESCRIPTION
This is really annoying! But we need to have a long enough timeout for now to allow for all the firmware updates.