### PR TITLE
build: move yarn cache location to mounted volume when building from CI

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -104,6 +104,7 @@ jobs:
           echo 'GITDIR = "/volumes/cache/git"' >> ./build/conf/local.conf
           echo 'SSTATE_DIR = "/volumes/cache/sstate"' >> ./build/conf/local.conf
           echo 'OT_BUILD_TYPE = "${{steps.build-refs.outputs.build-type}}"' >> ./build/conf/local.conf
+          echo 'YARN_CACHE_DIR = "/volumes/cache/yarn"' >> ./build/conf/local.conf
           cd ..
       - name: Pull S3 cache
         shell: bash

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -282,3 +282,4 @@ include conf/machine/include/${MACHINE}.inc
 
 # Custom variables
 OT_BUILD_TYPE = "develop"
+YARN_CACHE_DIR = ""

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -9,17 +9,15 @@ inherit features_check
 
 inherit insane
 
-YARN_CACHE_DIR = "${d.getVar("YARN_CACHE_DIR", "")}"
-
 do_configure(){
     npm install -g yarn
     cd ${S}
 
     # Move the yarn package configs to a mapped location when running in container
-    bberror("YARN_CACHE_DIR: ${YARN_CACHE_DIR}")
-    if [! -z "$YARN_CACHE_DIR"]:
-        bbnote("Seting the yarn cache location to - ${YARN_CACHE_DIR}")
+    if [ ! -z "${YARN_CACHE_DIR}" ]; then
+        bbnote "Seting the yarn cache location to - ${YARN_CACHE_DIR}"
         yarn config set cache-folder $YARN_CACHE_DIR
+    fi
 
     yarn
     cd ${S}/app-shell-odd

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -9,10 +9,18 @@ inherit features_check
 
 inherit insane
 
+YARN_CACHE_DIR = "${d.getVar("YARN_CACHE_DIR", "")}"
 
 do_configure(){
     npm install -g yarn
     cd ${S}
+
+    # Move the yarn package configs to a mapped location when running in container
+    bberror("YARN_CACHE_DIR: ${YARN_CACHE_DIR}")
+    if [! -z "$YARN_CACHE_DIR"]:
+        bbnote("Seting the yarn cache location to - ${YARN_CACHE_DIR}")
+        yarn config set cache-folder $YARN_CACHE_DIR
+
     yarn
     cd ${S}/app-shell-odd
     yarn electron-rebuild --arch=arm64

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -16,7 +16,7 @@ do_configure(){
     # Move the yarn package configs to a mapped location when running in container
     if [ ! -z "${YARN_CACHE_DIR}" ]; then
         bbnote "Seting the yarn cache location to - ${YARN_CACHE_DIR}"
-        yarn config set cache-folder $YARN_CACHE_DIR
+        yarn config set cache-folder "${YARN_CACHE_DIR}"
     fi
 
     yarn


### PR DESCRIPTION
yarn and node-modules were taking up a ton of space inside the docker container causing us to run out of space, so let's move the .cache location that yarn uses to cache modules to /volumes/cache/yarn which gets bind mounted outside the containers in CI.

![image](https://github.com/Opentrons/oe-core/assets/12740774/0200a8a8-10c8-48af-ba3b-84bc886380ab)