### PR TITLE
recipes-kernel: add M24128 EEPROM overlay to device tree

### DIFF
--- a/layers/meta-opentrons/conf/machine/verdin-imx8mm.conf
+++ b/layers/meta-opentrons/conf/machine/verdin-imx8mm.conf
@@ -88,6 +88,7 @@ TEZI_EXTERNAL_KERNEL_DEVICETREE_BOOT = "\
   verdin-imx8mm_gt911_overlay.dtbo \
   verdin-imx8mm_MCP2518_overlay.dtbo \
   verdin-imx8mm_force-lcd-on.dtbo \
+  verdin-imx8mm_M24128-eeprom_overlay.dtbo \
 "
 
 TORADEX_PRODUCT_IDS = "0055 0057 0059 0060"

--- a/layers/meta-opentrons/recipes-kernel/linux/device-tree-overlays_git.bbappend
+++ b/layers/meta-opentrons/recipes-kernel/linux/device-tree-overlays_git.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append = "\
   file://verdin-imx8mm_MCP2518_overlay.dts \
   file://verdin-imx8mm_usbotg1-force-peripheral.dts \
   file://verdin-imx8mm_force-lcd-on.dts \
+  file://verdin-imx8mm_M24128-eeprom_overlay.dts \
   "
 
 FILESEXTRAPATHS_append := ":${THISDIR}/overlays"

--- a/layers/meta-opentrons/recipes-kernel/linux/overlays/verdin-imx8mm_M24128-eeprom_overlay.dts
+++ b/layers/meta-opentrons/recipes-kernel/linux/overlays/verdin-imx8mm_M24128-eeprom_overlay.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2
+/*
+ * Copyright 2020-2021 Opentrons
+ */
+
+// add M24128 eeprom on carrier board.
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "toradex,verdin-imx8mm";
+};
+
+/* Disable EEPROM on display adapter boards */
+&eeprom_display_adapter {
+	status = "disabled";
+};
+
+/* Disable EEPROM on Verdin Development board */
+&eeprom_carrier_board {
+	status = "disabled";
+};
+
+/* Enable EEPROM M24128 on the Opentrons carrier board Verdin I2C_1 bus line.*/
+&i2c4 {
+	eeprom_opentrons_carrier_board: eeprom@50 {
+		compatible = "st,24c128";
+		pagesize = <64>;
+		reg = <0x50>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
We need to add the m24128 eeprom we are using in the Opentrons carrier board to the device tree so we can access the memory from userspace.


Closes: [RET-1345](https://opentrons.atlassian.net/browse/RET-1345)

Todo:
- [x] Make sure the M24128 eeprom is initialized on start-up and shows up on dmesg
- [x] Make sure we can read/write to /sys/bus/i2c/devices/3-0050

[RET-1345]: https://opentrons.atlassian.net/browse/RET-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ