### PR TITLE
build(fix): move electron cache dir to bind mounted for in CI

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -89,13 +89,6 @@ jobs:
           secret_access_key: ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }}
           region: us-east-2
           stage: ${{ matrix.build_env }}
-      - name: Symlink cache dir
-        shell: bash
-        run: |
-          here=$(pwd)
-          echo "current_dir: ${here}"
-          echo "$local_cache_dir: {LOCAL_CACHE:-./cache}"
-          df -ah
       - name: Build container
         run: |
           cd oe-core
@@ -112,7 +105,7 @@ jobs:
           echo 'SSTATE_DIR = "/volumes/cache/sstate"' >> ./build/conf/local.conf
           echo 'OT_BUILD_TYPE = "${{steps.build-refs.outputs.build-type}}"' >> ./build/conf/local.conf
           echo 'YARN_CACHE_DIR = "/volumes/cache/yarn"' >> ./build/conf/local.conf
-          echo 'ELECRON_CACHE_DIR = "/volumes/cache/electron"' >> ./build/conf/local.conf
+          echo 'ELECTRON_CACHE_DIR = "/volumes/cache/electron"' >> ./build/conf/local.conf
           cd ..
       - name: Pull S3 cache
         shell: bash

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -96,7 +96,6 @@ jobs:
           echo "current_dir: ${here}"
           echo "$local_cache_dir: {LOCAL_CACHE:-./cache}"
           df -ah
-          exit 1
       - name: Build container
         run: |
           cd oe-core
@@ -113,6 +112,7 @@ jobs:
           echo 'SSTATE_DIR = "/volumes/cache/sstate"' >> ./build/conf/local.conf
           echo 'OT_BUILD_TYPE = "${{steps.build-refs.outputs.build-type}}"' >> ./build/conf/local.conf
           echo 'YARN_CACHE_DIR = "/volumes/cache/yarn"' >> ./build/conf/local.conf
+          echo 'ELECRON_CACHE_DIR = "/volumes/cache/electron"' >> ./build/conf/local.conf
           cd ..
       - name: Pull S3 cache
         shell: bash

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -89,6 +89,14 @@ jobs:
           secret_access_key: ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }}
           region: us-east-2
           stage: ${{ matrix.build_env }}
+      - name: Symlink cache dir
+        shell: bash
+        run: |
+          here=$(pwd)
+          echo "current_dir: ${here}"
+          echo "$local_cache_dir: {LOCAL_CACHE:-./cache}"
+          df -ah
+          exit 1
       - name: Build container
         run: |
           cd oe-core

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -283,3 +283,4 @@ include conf/machine/include/${MACHINE}.inc
 # Custom variables
 OT_BUILD_TYPE = "develop"
 YARN_CACHE_DIR = ""
+ELECRON_CACHE_DIR = ""

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -283,4 +283,4 @@ include conf/machine/include/${MACHINE}.inc
 # Custom variables
 OT_BUILD_TYPE = "develop"
 YARN_CACHE_DIR = ""
-ELECRON_CACHE_DIR = ""
+ELECTRON_CACHE_DIR = ""

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -17,6 +17,7 @@ do_configure(){
     if [ ! -z "${YARN_CACHE_DIR}" ]; then
         bbnote "Seting the yarn cache location to - ${YARN_CACHE_DIR}"
         yarn config set cache-folder "${YARN_CACHE_DIR}"
+        export electron_config_cache="${ELECRON_CACHE_DIR}"
     fi
 
     yarn

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -17,7 +17,7 @@ do_configure(){
     if [ ! -z "${YARN_CACHE_DIR}" ]; then
         bbnote "Seting the yarn cache location to - ${YARN_CACHE_DIR}"
         yarn config set cache-folder "${YARN_CACHE_DIR}"
-        export electron_config_cache="${ELECRON_CACHE_DIR}"
+        export electron_config_cache="${ELECTRON_CACHE_DIR}"
     fi
 
     yarn

--- a/start.sh
+++ b/start.sh
@@ -17,13 +17,6 @@ cleanup () {
   popd >/dev/null
 }
 
-
-# FIX ME:
-# electron is BIG BAD and does not respect yarn download location
-# So we need to symlink the location it writes to, to a location on the host
-ln -s /volumes/cache/electron ~/.cache/electron
-
-
 DEFAULT_TARGET=opentrons-ot3-image
 THISDIR="${1}"
 shift

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,13 @@ cleanup () {
   popd >/dev/null
 }
 
+
+# FIX ME:
+# electron is BIG BAD and does not respect yarn download location
+# So we need to symlink the location it writes to, to a location on the host
+ln -s /volumes/cache/electron ~/.cache/electron
+
+
 DEFAULT_TARGET=opentrons-ot3-image
 THISDIR="${1}"
 shift


### PR DESCRIPTION
electron uses a separate cache location to that of yarn, which was causing yet another running out of space issue.