### PR TITLE
fix(build): create symlink for electron cache dir manually

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -17,7 +17,6 @@ do_configure(){
     if [ ! -z "${YARN_CACHE_DIR}" ]; then
         bbnote "Seting the yarn cache location to - ${YARN_CACHE_DIR}"
         yarn config set cache-folder "${YARN_CACHE_DIR}"
-        bberror "CACHE_DIR: ${ELECTRON_CACHE_DIR}"
         export electron_config_cache="${ELECTRON_CACHE_DIR}"
     fi
 

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -17,6 +17,7 @@ do_configure(){
     if [ ! -z "${YARN_CACHE_DIR}" ]; then
         bbnote "Seting the yarn cache location to - ${YARN_CACHE_DIR}"
         yarn config set cache-folder "${YARN_CACHE_DIR}"
+        bberror "CACHE_DIR: ${ELECTRON_CACHE_DIR}"
         export electron_config_cache="${ELECTRON_CACHE_DIR}"
     fi
 

--- a/start.sh
+++ b/start.sh
@@ -35,8 +35,8 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
-mkdir -p ~/.cache/electron
-ln -s /volumes/cache/electron ~/.cache/electron/
+mkdir -p /volumes/cache/electron
+ln -sf /volumes/cache/electron ~/.config/electron
 
 ls -la /volumes
 ls -la /volumes/cache/

--- a/start.sh
+++ b/start.sh
@@ -35,6 +35,7 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
+mkdir -p ~/.cache/electron
 ln -s /volumes/cache/electron ~/.cache/electron/
 
 ls -la /volumes

--- a/start.sh
+++ b/start.sh
@@ -38,5 +38,10 @@ ls -la /volumes/cache/
 
 df -h
 
+# electron is ignoring the cache download set by the electron_config_cache env var
+# so for now lets manually create a symlink and set its download location to /volumes/cache
+ln -s /volumes/cache/electron ~/.cache/electron/
+
+
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?

--- a/start.sh
+++ b/start.sh
@@ -33,5 +33,10 @@ patch -f ./layers/meta-jupyter/conf/layer.conf ./meta-jupyter-backport.patch
 export BITBAKEDIR=${THISDIR}/tools/bitbake
 . layers/openembedded-core/oe-init-build-env ${THISDIR}/build
 
+ls -la /volumes
+ls -la /volumes/cache/
+
+df -h
+
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?

--- a/start.sh
+++ b/start.sh
@@ -36,7 +36,7 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
 mkdir -p /volumes/cache/electron
-ln -sf /volumes/cache/electron ~/.config/electron
+ln -sf /volumes/cache/electron ~/.cache/electron
 
 ls -la /volumes
 ls -la /volumes/cache/

--- a/start.sh
+++ b/start.sh
@@ -39,11 +39,5 @@ mkdir -p /volumes/cache/electron
 mkdir -p ~/.cache/
 ln -sf /volumes/cache/electron ~/.cache/electron
 
-ls -la ~/.cache
-ls -la /volumes
-ls -la /volumes/cache/
-
-df -h
-
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?

--- a/start.sh
+++ b/start.sh
@@ -36,8 +36,10 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
 mkdir -p /volumes/cache/electron
+mkdir -p ~/.cache/electron
 ln -sf /volumes/cache/electron ~/.cache/electron
 
+ls -la ~/.cache
 ls -la /volumes
 ls -la /volumes/cache/
 

--- a/start.sh
+++ b/start.sh
@@ -36,7 +36,7 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
 mkdir -p /volumes/cache/electron
-mkdir -p ~/.cache/electron
+mkdir -p ~/.cache/
 ln -sf /volumes/cache/electron ~/.cache/electron
 
 ls -la ~/.cache

--- a/start.sh
+++ b/start.sh
@@ -33,15 +33,14 @@ patch -f ./layers/meta-jupyter/conf/layer.conf ./meta-jupyter-backport.patch
 export BITBAKEDIR=${THISDIR}/tools/bitbake
 . layers/openembedded-core/oe-init-build-env ${THISDIR}/build
 
-ls -la /volumes
-ls -la /volumes/cache/
-
-df -h
-
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
 ln -s /volumes/cache/electron ~/.cache/electron/
 
+ls -la /volumes
+ls -la /volumes/cache/
+
+df -h
 
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?


### PR DESCRIPTION
The `electron_cache_dir` env variable is being ignored when set from opentrons-robot-app recipe, so lets just manually create a symlink from `~/.cache/electron` -> `/volumes/cache/electron` which bind mounts to a larger partition in the ec2 instance.