### PR TITLE
opentrons-systemd-units: fix machine-id being re-generated after reboot

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/opentrons-commit-machine-id.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/opentrons-commit-machine-id.service
@@ -1,0 +1,6 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ot-commit-machine-id
+
+[Install]
+WantedBy=basic.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-commit-machine-id
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-commit-machine-id
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+
+# Make sure the device's random machine ID is saved to persistent storage on
+# the active root filesystem. If it's already been saved, do nothing.
+#
+# This matters for the first boot after flashing a fresh SD card.
+#
+#
+# Background:
+#
+# /etc/machine-id should contain a unique identifier for this device, and it
+# should remain constant across reboots. Userspace programs like journald rely
+# on this.
+#
+# /etc/machine-id comes unpopulated on our SD card images. So, when the system
+# boots, systemd autogenerates a random, transient machine ID in its place. It
+# bind-mounts that transient ID atop /etc/machine-id so that other userspace
+# programs will be able to find it there.
+#
+#  +---------------------------+
+#  | temp file with random ID  |
+#  +---------------------------+
+#               |
+#     bind-mounted by systemd
+#               |
+#               V
+#  +---------------------------+
+#  | regular file, unpopulated |
+#  +---------------------------+
+#               |
+#         on filesystem
+#               |
+#               V
+#        /etc/machine-id
+#
+# Normally, systemd-machine-id-commit.service eventually writes this transient
+# ID back to persistent storage, so that it's properly constant across reboots.
+# But on our system, that doesn't work, because we mount our root filesystem
+# read-only.
+#
+# This script takes the place of systemd-machine-id-commit.service.
+# It commits the transient ID to persistent storage, but in a way that avoids
+# having to remount the whole root filesystem as writeable (which would open
+# it up to uncontrolled modifications).
+#
+# See also our update-server, which preserves machine IDs across system updates
+# through a similar fixup.
+
+
+set -eu -o pipefail
+
+MACHINE_ID_FILE=/etc/machine-id
+
+function already_committed {
+    # Return success if there's already a machine ID committed to persistent
+    # storage, or false otherwise.
+
+    # todo(mm, 2021-02-25): Instead of checking like this, should we use
+    # systemd's ConditionFirstBoot to only run this script at all on first boot?
+
+    # If $MACHINE_ID_FILE was unpopulated at the beginning of this
+    # boot, then systemd will have bind-mounted a transient file atop it.
+    ! findmnt --mountpoint "$MACHINE_ID_FILE" > /dev/null
+}
+
+if already_committed
+then
+    printf "machine-id"
+    printf " \"$(cat "$MACHINE_ID_FILE")\""
+    printf " already committed."
+    printf " Exiting without doing anything.\n"
+    exit
+fi
+
+# To write stuff in the root filesystem while keeping it read-only to everyone
+# else: mount it at an additional second place, somewhere off to the side where
+# only we will touch it, and make that mount writeable.
+#
+# Bind mounts don't recursively include submounts, so when we access the
+# machine-id file through this, we'll hit the real underlying file instead of
+# the temporary one that systemd bind-mounted atop it.
+rw_remount_point=$(mktemp -d -t "$(basename "$0")XXXXXXXXXX")
+function clean_up {
+    umount "$rw_remount_point" || true
+    rmdir "$rw_remount_point" || true
+}
+trap clean_up EXIT
+mount --bind / "$rw_remount_point"
+# `mount --bind` quirk: the `-o rw` needs to be in a separate remount command.
+mount -o remount,rw "$rw_remount_point"
+
+# Unfortunately, we can't make this write atomic with `cp` because it errors
+# with "device or resource busy." The underlying file is serving as the mount
+# point for systemd's bind mount, so possibly, it can't be removed or replaced
+# (even though it can have its contents rewritten).
+rw_underlying_machine_id_file="$rw_remount_point/$MACHINE_ID_FILE"
+cat "$MACHINE_ID_FILE" > "$rw_underlying_machine_id_file"
+
+printf "Committed machine-id \"$(cat "$rw_underlying_machine_id_file")\".\n"

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-commit-machine-id
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-commit-machine-id
@@ -3,7 +3,7 @@
 # Make sure the device's random machine ID is saved to persistent storage on
 # the active root filesystem. If it's already been saved, do nothing.
 #
-# This matters for the first boot after flashing a fresh SD card.
+# This matters for the first boot after flashing a fresh SOM image.
 #
 #
 # Background:
@@ -12,7 +12,7 @@
 # should remain constant across reboots. Userspace programs like journald rely
 # on this.
 #
-# /etc/machine-id comes unpopulated on our SD card images. So, when the system
+# /etc/machine-id comes unpopulated on our SOM images. So, when the system
 # boots, systemd autogenerates a random, transient machine ID in its place. It
 # bind-mounts that transient ID atop /etc/machine-id so that other userspace
 # programs will be able to find it there.
@@ -54,9 +54,6 @@ MACHINE_ID_FILE=/etc/machine-id
 function already_committed {
     # Return success if there's already a machine ID committed to persistent
     # storage, or false otherwise.
-
-    # todo(mm, 2021-02-25): Instead of checking like this, should we use
-    # systemd's ConditionFirstBoot to only run this script at all on first boot?
 
     # If $MACHINE_ID_FILE was unpopulated at the beginning of this
     # boot, then systemd will have bind-mounted a transient file atop it.

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/opentrons-systemd-units.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/opentrons-systemd-units.bb
@@ -29,5 +29,5 @@ do_install() {
 
    # install supporting files
    install -d ${D}/${bindir}
-   install -m 0644 ${WORKDIR}/ot-commit-machine-id ${D}/${bindir}/ot-commit-machine-id
+   install -m 0744 ${WORKDIR}/ot-commit-machine-id ${D}/${bindir}/ot-commit-machine-id
 }

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/opentrons-systemd-units.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/opentrons-systemd-units.bb
@@ -7,17 +7,27 @@ inherit systemd
 FILESEXTRAPATHS_prepend = "${THISDIR}/files:"
 SRC_URI += "\
       file://var-log-journal.service \
+      file://opentrons-commit-machine-id.service \
+      file://ot-commit-machine-id \
       "
 
 SYSTEMD_AUTO_ENABLE = "enable"
-SYSTEMD_SERVICE_${PN} = "var-log-journal.service"
+SYSTEMD_SERVICE_${PN} += "var-log-journal.service"
+SYSTEMD_SERVICE_${PN} += "opentrons-commit-machine-id.service"
 SYSTEMD_PACKAGES = "${PN}"
 
 FILES_${PN} += "\
       ${systemd_system_unitdir}/var-log-journal.service \
+      ${systemd_system_unitdir}/opentrons-commit-machine-id.service \
+      ${bindir}/ot-commit-machine-id \
       "
 
 do_install() {
    install -d ${D}/${systemd_system_unitdir}
    install -m 0644 ${WORKDIR}/var-log-journal.service ${D}/${systemd_system_unitdir}/var-log-journal.service
+   install -m 0644 ${WORKDIR}/opentrons-commit-machine-id.service ${D}/${systemd_system_unitdir}/opentrons-commit-machine-id.service
+
+   # install supporting files
+   install -d ${D}/${bindir}
+   install -m 0644 ${WORKDIR}/ot-commit-machine-id ${D}/${bindir}/ot-commit-machine-id
 }


### PR DESCRIPTION
## Overview 

The `/etc/machine-id` is used by systemd for a few different things, including serving as the unique identifier for journald logs. This usually persists through power cycles and updates, but our rootfs is read-only so we need to do some workaround to get it to persist. 

This pr adds that workaround, by adding a systemd service that takes over for the [systemd-machine-id-commit.service](https://www.freedesktop.org/software/systemd/man/systemd-machine-id-commit.service.html#). Our service bind-mounts the `/etc/machine-id` file in a temporary read-write location at which point we write the machine-id which writes to the underlying machine-id file, making it persist over reboots and power cycles. See the ticket below for more details

Closes: [RCORE-706](https://opentrons.atlassian.net/browse/RCORE-706)

## Test Plan

- [ ] Flash the image on the robot and make sure the `/etc/machine-id` persists through power cycles
- [ ] Update the robot OTA and make sure the `/etc/machine-id` persists

