### PR TITLE
recipes-core/base-files: mount the /mnt dir to /userfs/var/mnt so the machine-id can persist through updates.

### DIFF
--- a/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
+++ b/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
@@ -12,5 +12,6 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 /userfs/home             /home                 none       defaults,bind         0  0
 /userfs/data             /data                 none       defaults,bind         0  0
 /userfs/var              /var                  none       defaults,bind         0  0
+/userfs/var/mnt          /mnt                  none       defaults,bind         0  0
 /userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail  0  0
 /userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail  0  0


### PR DESCRIPTION
Works with [this](https://github.com/Opentrons/opentrons/pull/13077) monorepo change to fix the machine-id not persisting through updates.