### PR TITLE
build(fix): Manually set yarn download dir to cached location.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -36,8 +36,10 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 # electron is ignoring the cache download set by the electron_config_cache env var
 # so for now lets manually create a symlink and set its download location to /volumes/cache
 mkdir -p /volumes/cache/electron
+mkdir -p /volumes/cache/yarn
 mkdir -p ~/.cache/
 ln -sf /volumes/cache/electron ~/.cache/electron
+ln -sf /volumes/cache/yarn ~/.cache/yarn
 
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?


### PR DESCRIPTION
here we go again...

We should be setting the yarn download dir to /volumes/cache/yarn within the opentrons-robot-app.bb recipe, but for some reason that's being ignored, so let's just manually set the download dir with a symlink as we do for electron.