### PR TITLE
meta-opentrons: robot-app: remove cypress

### DIFF
--- a/layers/meta-opentrons/recipes-robot/robot-app/robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/robot-app/robot-app.bb
@@ -13,6 +13,7 @@ inherit insane
 do_configure(){
     npm install -g yarn
     cd ${S}
+    yarn remove -W cypress @cypress/webpack-preprocessor cypress-file-upload eslint-plugin-cypress
     yarn
     cd ${S}/app-shell
     yarn electron-rebuild --arch=arm64


### PR DESCRIPTION
Cypress is gigantic and downloads to the wrong place. Preemptively remove it from the node dependencies since it's not necessary for building the actual app.