### PR TITLE
fix(build): add OPENTRONS_PROJECT var to local.conf so we can do local builds.

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -281,6 +281,7 @@ DISTRO = "opentrons"
 include conf/machine/include/${MACHINE}.inc
 
 # Custom variables
+OPENTRONS_PROJECT = "ot3"
 OT_BUILD_TYPE = "develop"
 YARN_CACHE_DIR = ""
 ELECTRON_CACHE_DIR = ""


### PR DESCRIPTION
The OPENTRONS_PROJECT var is set by CI during a build, but nothing sets it for local builds so the Opentrons python packages that rely on it fail to compile.