### PR TITLE
opentrons-ot3-image: fix build signing by adding signing key to the rootfs.

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -112,8 +112,6 @@ jobs:
           cat <<EOF >./build/.signing-key
           ${{secrets.ROBOT_SIGNING_KEY}}
           EOF
-          ## Test
-          cat ./build/conf/local.conf
           cd ..
       - name: Pull S3 cache
         shell: bash

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -112,6 +112,8 @@ jobs:
           cat <<EOF >./build/.signing-key
           ${{secrets.ROBOT_SIGNING_KEY}}
           EOF
+          ## Test
+          cat ./build/conf/local.conf
           cd ..
       - name: Pull S3 cache
         shell: bash

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -182,4 +182,4 @@ do_install () {
 }
 
 
-FILES_${PN} += "${PIPENV_APP_BUNDLE_DIR} opentrons_versions"
+FILES_${PN} = "${PIPENV_APP_BUNDLE_DIR} opentrons_versions"

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -291,7 +291,7 @@ do_create_opentrons_ot3() {
     # sign the hash
     signed_rootfs=""
     if [ -e "${SIGNING_KEY}" ]; then
-        bbnote "Signing the build"
+        bberror "Signing the build"
         openssl dgst -sha256 -sign "${SIGNING_KEY}" -out systemfs.xz.hash.sig systemfs.xz.sha256
         signed_rootfs="systemfs.xz.hash.sig"
     fi

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -141,7 +141,7 @@ do_make_rootfs_changes() {
     cat ${IMAGE_ROOTFS}${sysconfdir}/release-notes.md > ${DEPLOY_DIR_IMAGE}/release-notes.md
     # copy the signing key if we have a signing key
     if [ -e "${SIGNING_KEY}" ]; then
-       bbinfo "Installing pubkey to require signed updates"
+       bbnote "Installing pubkey to require signed updates"
        install -m 644 ${IMAGE_ROOTFS}/opentrons_versions/opentrons-robot-signing-key.crt ${IMAGE_ROOTFS}${sysconfdir}/
     fi
 

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -139,6 +139,11 @@ do_make_rootfs_changes() {
     cat ${DEPLOY_DIR_IMAGE}/VERSION.json > ${IMAGE_ROOTFS}${sysconfdir}/VERSION.json
     # copy the release notes to the output dir
     cat ${IMAGE_ROOTFS}${sysconfdir}/release-notes.md > ${DEPLOY_DIR_IMAGE}/release-notes.md
+    # copy the signing key if we have a signing key
+    if [ -e "${SIGNING_KEY}" ]; then
+       bbinfo "Installing pubkey to require signed updates"
+       install -m 644 ${IMAGE_ROOTFS}/opentrons_versions/opentrons-robot-signing-key.crt ${IMAGE_ROOTFS}${sysconfdir}/
+    fi
 
     # add hostname to rootfs
     printf "opentrons" > ${IMAGE_ROOTFS}${sysconfdir}/hostname

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -139,7 +139,8 @@ do_make_rootfs_changes() {
     cat ${DEPLOY_DIR_IMAGE}/VERSION.json > ${IMAGE_ROOTFS}${sysconfdir}/VERSION.json
     # copy the release notes to the output dir
     cat ${IMAGE_ROOTFS}${sysconfdir}/release-notes.md > ${DEPLOY_DIR_IMAGE}/release-notes.md
-    # copy the signing key if we have a signing key
+
+    # copy the robot cert if we have a signing key
     if [ -e "${SIGNING_KEY}" ]; then
        bbnote "Installing pubkey to require signed updates"
        install -m 644 ${IMAGE_ROOTFS}/opentrons_versions/opentrons-robot-signing-key.crt ${IMAGE_ROOTFS}${sysconfdir}/

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -296,7 +296,7 @@ do_create_opentrons_ot3() {
     # sign the hash
     signed_rootfs=""
     if [ -e "${SIGNING_KEY}" ]; then
-        bberror "Signing the build"
+        bbnote "Signing the build"
         openssl dgst -sha256 -sign "${SIGNING_KEY}" -out systemfs.xz.hash.sig systemfs.xz.sha256
         signed_rootfs="systemfs.xz.hash.sig"
     fi

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -44,6 +44,6 @@ do_install_append() {
 }
 
 # Only include cert if the signing key is given
-FILES_${PN}_append := "${@bb.utils.contains("SIGNING_KEY", "", " ${sysconfdir}/opentrons-robot-signing-key.crt ", "", d)}"
+FILES_${PN}_append := "${@bb.utils.contains("SIGNING_KEY", "", "", " ${sysconfdir}/opentrons-robot-signing-key.crt ", d)}"
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -44,6 +44,6 @@ do_install_append() {
 }
 
 # Only include cert if the signing key is given
-FILES_${PN} += "${@'${sysconfdir}/ \ ${sysconfdir}/opentrons-robot-signing-key.crt' if os.path.exists(d.getVar('SIGNING_KEY') else '')}"
+FILES_${PN} += "${@bb.utils.contains('SIGNING_KEY', '', '', '${sysconfdir}/ \${sysconfdir}/opentrons-robot-signing-key.crt \', d)}"
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -36,18 +36,14 @@ do_install_append() {
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/opentrons-update-server.service ${D}/${systemd_unitdir}/system
 
-  if [ -e "${SIGNING_KEY}" ]; then
+  if [ -z "${SIGNING_KEY}" ]; then
     bbnote "Installing pubkey to require signed updates"
     install -d ${D}/${sysconfdir}
     install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/${sysconfdir}/opentrons-robot-signing-key.crt
   fi
 }
 
-if [ -e "${SIGNING_KEY}" ]; then
-   FILES_${PN} += "\
-                  ${sysconfdir}/ \
-                  ${sysconfdir}/opentrons-robot-signing-key.crt \
-                  "
-fi
+# Only include cert if the signing key is given
+FILES_${PN} += "${@'${sysconfdir}/ \ ${sysconfdir}/opentrons-robot-signing-key.crt' if os.path.exists(d.getVar('SIGNING_KEY') else '')}"
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -43,7 +43,7 @@ do_install_append() {
   fi
 }
 
-# Only include cert if the signing key is given
-FILES_${PN}_append := "${@bb.utils.contains("SIGNING_KEY", "", "", " ${sysconfdir}/opentrons-robot-signing-key.crt ", d)}"
+# Only include cert if the signing key is set
+FILES_${PN}_append := "${@bb.utils.contains('SIGNING_KEY', '', ' ${sysconfdir}/opentrons-robot-signing-key.crt ', '', d)}"
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -28,9 +28,6 @@ PIPENV_APP_BUNDLE_EXTRAS = ""
 PIPENV_APP_BUNDLE_USE_GLOBAL = "python3-aiohttp systemd-python"
 PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=${OPENTRONS_PROJECT}"
 
-# Only include cert if the signing key is set
-FILES_${PN}_append := "${@bb.utils.contains('SIGNING_KEY', '', ' ${sysconfdir}/opentrons-robot-signing-key.crt ', '', d)}"
-
 do_install_append() {
   # create json file to be used in VERSION.json
   install -d ${D}/opentrons_versions
@@ -39,13 +36,8 @@ do_install_append() {
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/opentrons-update-server.service ${D}/${systemd_unitdir}/system
 
-  bberror "FILES: ${FILES_${PN}}"
-  if [ -e "${SIGNING_KEY}" ]; then
-    bberror "Installing pubkey to require signed updates"
-    install -d ${D}/${sysconfdir}
-    install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/${sysconfdir}/
-  fi
+  # install the signing key, we decide if we keep it in the opentrons-ot3-image recipe
+  install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/opentrons_versions/opentrons-robot-signing-key.crt
 }
-
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -13,7 +13,7 @@ inherit insane systemd
 
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "opentrons-update-server.service"
-FILESEXTRAPATHS_prepend = "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "\
            file://opentrons-update-server.service \
            file://opentrons-robot-signing-key.crt \

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -36,15 +36,18 @@ do_install_append() {
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/opentrons-update-server.service ${D}/${systemd_unitdir}/system
 
-  # install the cert key if this is a release build
-  if [ ${OT_BUILD_TYPE} =~ "release" ]; then
+  if [ -e "${SIGNING_KEY}" ]; then
     bbnote "Installing pubkey to require signed updates"
     install -d ${D}/${sysconfdir}
     install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/${sysconfdir}/opentrons-robot-signing-key.crt
   fi
 }
 
-# Only include cert if this is a release build
-FILES_${PN} += "${@bb.utils.contains('OT_BUILD_TYPE', 'release', '${sysconfdir}/ \${sysconfdir}/opentrons-robot-signing-key.crt', '', d)}"
+if [ -e "${SIGNING_KEY}" ]; then
+   FILES_${PN} += "\
+                  ${sysconfdir}/ \
+                  ${sysconfdir}/opentrons-robot-signing-key.crt \
+                  "
+fi
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -28,6 +28,9 @@ PIPENV_APP_BUNDLE_EXTRAS = ""
 PIPENV_APP_BUNDLE_USE_GLOBAL = "python3-aiohttp systemd-python"
 PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=${OPENTRONS_PROJECT}"
 
+# Only include cert if the signing key is set
+FILES_${PN}_append := "${@bb.utils.contains('SIGNING_KEY', '', ' ${sysconfdir}/opentrons-robot-signing-key.crt ', '', d)}"
+
 do_install_append() {
   # create json file to be used in VERSION.json
   install -d ${D}/opentrons_versions
@@ -36,14 +39,13 @@ do_install_append() {
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/opentrons-update-server.service ${D}/${systemd_unitdir}/system
 
-  if [ -z "${SIGNING_KEY}" ]; then
-    bbnote "Installing pubkey to require signed updates"
+  bberror "FILES: ${FILES_${PN}}"
+  if [ -e "${SIGNING_KEY}" ]; then
+    bberror "Installing pubkey to require signed updates"
     install -d ${D}/${sysconfdir}
     install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/${sysconfdir}/
   fi
 }
 
-# Only include cert if the signing key is set
-FILES_${PN}_append := "${@bb.utils.contains('SIGNING_KEY', '', ' ${sysconfdir}/opentrons-robot-signing-key.crt ', '', d)}"
 
 inherit pipenv_app_bundle

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -39,11 +39,11 @@ do_install_append() {
   if [ -z "${SIGNING_KEY}" ]; then
     bbnote "Installing pubkey to require signed updates"
     install -d ${D}/${sysconfdir}
-    install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/${sysconfdir}/opentrons-robot-signing-key.crt
+    install -m 600 ${WORKDIR}/opentrons-robot-signing-key.crt ${D}/${sysconfdir}/
   fi
 }
 
 # Only include cert if the signing key is given
-FILES_${PN} += "${@bb.utils.contains('SIGNING_KEY', '', '', '${sysconfdir}/ \${sysconfdir}/opentrons-robot-signing-key.crt \', d)}"
+FILES_${PN}_append := "${@bb.utils.contains("SIGNING_KEY", "", " ${sysconfdir}/opentrons-robot-signing-key.crt ", "", d)}"
 
 inherit pipenv_app_bundle


### PR DESCRIPTION
# Overview
For whatever reason Yocto likes to remove the CRT key, which means we weren't able to actually verify the updates. So instead of installing the CRT directly on the rootfs, do an install as a postrootfs change before we create the rootfs.

# Testing
- [x] Successfully install on a robot that did not have the `/etc/opentrons-robot-signing-key.crt` file
- [x] Once installed, re-install the same update to verify that the signature is correct before updating.
- [x] Once installed, rejects updates that don't have the `systemfs.xz.hash.sig` file
- [x] Once installed, rejects updates that have an invalid `systemfs.xz.hash.sig` file