### PR TITLE
build: fix project, fix release type

### DIFF
--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -138,8 +138,13 @@ const BUILD_TYPE_TEST_SPECS: Array<[string, [Ref], BuildType]> = [
     'develop',
   ],
   [
-    'when monorepo ref is a release tag is release',
+    'when monorepo ref is an internal-release tag is release',
     ['refs/tags/ot3@0.0.0-dev'],
+    'release',
+  ],
+  [
+    'when monorepo ref is a release tag is release',
+    ['refs/tags/v12.12.9-alpha.12'],
     'release',
   ],
 ]

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -205,7 +205,7 @@ async function resolveRefs(toAttempt: AttemptableRefs): Promise<OutputRefs> {
 }
 
 export function resolveBuildType(ref: Ref): BuildType {
-  return ref.includes('refs/tags/ot3') ? 'release' : 'develop'
+  return ref.includes('refs/tags') ? 'release' : 'develop'
 }
 
 async function run() {

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -9885,7 +9885,7 @@ function resolveRefs(toAttempt) {
     });
 }
 function resolveBuildType(ref) {
-    return ref.includes('refs/tags/ot3') ? 'release' : 'develop';
+    return ref.includes('refs/tags') ? 'release' : 'develop';
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {

--- a/layers/meta-opentrons/classes/get_ot_package_version.bbclass
+++ b/layers/meta-opentrons/classes/get_ot_package_version.bbclass
@@ -10,7 +10,7 @@ def get_ot_package_version(d):
     try:
         sys.path.append(os.path.join(s, 'scripts'))
         from python_build_utils import get_version
-        return get_version(d.getVar('OT_PACKAGE', 'robot-server'), 'ot3')
+        return get_version(d.getVar('OT_PACKAGE', 'robot-server'), d.getVar('OPENTRONS_PROJECT', 'ot3'))
     finally:
         sys.path = sys.path[:-1]
 

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -36,8 +36,8 @@ do_install_append () {
 
     # create json file to be used in VERSION.json
     install -d ${D}/opentrons_versions
-    python3 ${S}/scripts/python_build_utils.py robot-server ot3 dump_br_version > ${D}/opentrons_versions/opentrons-robot-server-version.json
-    python3 ${S}/scripts/python_build_utils.py api ot3 dump_br_version > ${D}/opentrons_versions/opentrons-api-version.json
+    python3 ${S}/scripts/python_build_utils.py robot-server ${OPENTRONS_PROJECT} dump_br_version > ${D}/opentrons_versions/opentrons-robot-server-version.json
+    python3 ${S}/scripts/python_build_utils.py api ${OPENTRONS_PROJECT} dump_br_version > ${D}/opentrons_versions/opentrons-api-version.json
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-robot-server.service ${D}${systemd_system_unitdir}/opentrons-robot-server.service

--- a/layers/meta-opentrons/recipes-robot/opentrons-system-server/opentrons-system-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-system-server/opentrons-system-server.bb
@@ -29,7 +29,7 @@ addtask do_write_systemd_dropfile after do_compile before do_install
 do_install_append () {
     # create json file to be used in VERSION.json
     install -d ${D}/opentrons_versions
-    python3 ${S}/scripts/python_build_utils.py system-server ot3 dump_br_version > ${D}/opentrons_versions/opentrons-system-server-version.json
+    python3 ${S}/scripts/python_build_utils.py system-server ${OPENTRONS_PROJECT} dump_br_version > ${D}/opentrons_versions/opentrons-system-server-version.json
 
     install -d ${D}/${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-system-server.service ${D}/${systemd_system_unitdir}/opentrons-system-server.service

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/opentrons-update-server.bb
@@ -31,7 +31,7 @@ PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=${OPENTRONS_PROJECT}"
 do_install_append() {
   # create json file to be used in VERSION.json
   install -d ${D}/opentrons_versions
-  python3 ${S}/scripts/python_build_utils.py update-server ot3 dump_br_version > ${D}/opentrons_versions/opentrons-update-server-version.json
+  python3 ${S}/scripts/python_build_utils.py update-server ${OPENTRONS_PROJECT} dump_br_version > ${D}/opentrons_versions/opentrons-update-server-version.json
 
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/opentrons-update-server.service ${D}/${systemd_unitdir}/system

--- a/layers/meta-opentrons/recipes-robot/opentrons-usb-bridge/opentrons-usb-bridge.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-usb-bridge/opentrons-usb-bridge.bb
@@ -28,7 +28,7 @@ PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=${OPENTRONS_PROJECT}"
 do_install_append() {
   # create json file to be used in VERSION.json
   install -d ${D}/opentrons_versions
-  python3 ${S}/scripts/python_build_utils.py usb-bridge ot3 dump_br_version > ${D}/opentrons_versions/opentrons-usb-bridge-version.json
+  python3 ${S}/scripts/python_build_utils.py usb-bridge ${OPENTRONS_PROJECT} dump_br_version > ${D}/opentrons_versions/opentrons-usb-bridge-version.json
 
   install -d ${D}/${systemd_system_unitdir}
   install -m 0644 ${WORKDIR}/opentrons-usb-bridge.service ${D}/${systemd_system_unitdir}/opentrons-usb-bridge.service


### PR DESCRIPTION
Two build problems:
- We specify `OPENTRONS_PROJECT` when running pipenv, but in oe-core that's not where it's needed - it needs to be passed to the explicit get-version commands, which it now is. Here's a version json from a successful build: https://builds.opentrons.com/ot3-oe/5870014223/VERSION.json
- We need to determine that this is a release if there is _any_ tag, not just an `ot3` prefix tag