### PR TITLE
base-files: added /media to custom fstab so we can auto-mount thumbdrives.

### DIFF
--- a/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
+++ b/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
@@ -11,6 +11,7 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 /dev/mmcblk0p4           /userfs               auto       rw,x-systemd.growfs   0  2
 /userfs/home             /home                 none       defaults,bind         0  0
 /userfs/data             /data                 none       defaults,bind         0  0
+/userfs/media            /media                none       defaults,bind         0  0
 /userfs/var              /var                  none       defaults,bind         0  0
 /userfs/var/mnt          /mnt                  none       defaults,bind         0  0
 /userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail  0  0

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -178,6 +178,7 @@ fakeroot do_create_filesystem() {
     rsync -aH --chown=root:root ${IMAGE_ROOTFS}/home ${USERFS_DIR}/
     rsync -aH --chown=root:root ${IMAGE_ROOTFS}/var ${USERFS_DIR}/
     mkdir -p ${USERFS_DIR}/data
+    mkdir -p ${USERFS_DIR}/media
     mkdir -p ${USERFS_DIR}${sysconfdir}
     rm -rf ${USERFS_DIR}/var/log
     mkdir -p ${USERFS_DIR}/var/log


### PR DESCRIPTION
The `/etc/udev/scripts/mount.sh` script mounts usb thumb drives to "/media" but since the rootfs is read-only we cant, so lets bind-mount /media to the `/userfs/media` read-write partition.