### PR TITLE
opentrons-ssh-keys: always install file

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-ssh-keys/opentrons-ssh-keys.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-ssh-keys/opentrons-ssh-keys.bb
@@ -9,6 +9,10 @@ do_install () {
     if [[ "${OT_BUILD_TYPE}" =~ "develop" ]]; then
         bbnote "Installing default ssh rsa key"
         install -m 644 ${WORKDIR}/opentrons-flex.pub ${D}/home/root/.ssh/authorized_keys
+    else
+        bbnote "Establishing empty authorized_keys"
+        touch ${WORKDIR}/authorized_keys
+        install -m 644 ${WORKDIR}/authorized_keys ${D}/home/root/.ssh/authorized_keys
     fi
 }
 


### PR DESCRIPTION
We weren't installing the key in the release execution branch but were still providing it in the OE recipe. At some point we should make the build mode and project actual OE build variables that you can establish recipe variants on but for now just put an empty file in there in the other branch.