### PR TITLE
chore(build): Improve build caching so subsequent builds dont take so long.

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -331,6 +331,6 @@ jobs:
         run: |
           rm -rf ./*
       - name: Remove poisoned cache
-        if: ${{ !success() }}
+        if: ${{ failure() }}
         run: |
           rm -rf ${LOCAL_CACHE:-./cache}/*

--- a/start.sh
+++ b/start.sh
@@ -37,9 +37,11 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 # so for now lets manually create a symlink and set its download location to /volumes/cache
 mkdir -p /volumes/cache/electron
 mkdir -p /volumes/cache/yarn
+mkdir -p /volumes/cache/pip
 mkdir -p ~/.cache/
 ln -sf /volumes/cache/electron ~/.cache/electron
 ln -sf /volumes/cache/yarn ~/.cache/yarn
+ln -sf /volumes/cache/pip ~/.cache/pip
 
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?


### PR DESCRIPTION
- Don't clear cache (downloads, sstate, git) unless the build explicitly fails and is not just canceled.
- Create symlink for pip cache so it persists through builds