### PR TITLE
fix: make builds go fast again

### DIFF
--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -159,7 +159,7 @@ do_compile () {
 
    ${PYTHON} -m pip install \
       -t ${B}/pip-buildenv \
-      hatchling flit flit-core setuptools setuptools-scm[toml] wheel \
+      hatchling flit flit-core setuptools setuptools-scm[toml] wheel distutils\
 
 
    ${PIP_ENVARGS} PYTHONPATH=${B}/pip-buildenv:${PYTHONPATH} ${PYTHON} -m pip install \

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -154,26 +154,10 @@ PIP_ARGS := "--no-compile \
 do_compile () {
    mkdir -p ${B}/pip-downloads
 
-   bbnote "Installing common build deps ahead of time"
-
-   ${PYTHON} -m pip download \
-      --dest=${B}/pip-downloads \
-      -- \
-      flit flit-core hatchling setuptools setuptools_scm[toml]
-
-   bbnote "Downloading pypi packages"
-
-   ${PIP_ENVARGS} ${PYTHON} -m pip download \
-      -r ${B}/pypi.txt \
-      --no-deps \
-      --no-binary :all: \
-      --dest=${B}/pip-downloads/ \
-      -vvv
-
    bbnote "Installing pypi packages"
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
-      --no-index --find-links=${B}/pip-downloads/ \
+      --no-use-pep517 \
       ${PIP_ARGS} \
       -r ${B}/pypi.txt \
       --no-deps \
@@ -183,6 +167,7 @@ do_compile () {
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       -r ${B}/local.txt \
+      --no-use-pep517 \
       ${PIP_ARGS} \
       --no-deps \
       --use-feature=in-tree-build \
@@ -192,6 +177,7 @@ do_compile () {
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       ${PIPENV_APP_BUNDLE_PROJECT_ROOT} \
+      --no-use-pep517 \
       --use-feature=in-tree-build \
       --no-deps \
       ${PIP_ARGS} \

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -152,22 +152,43 @@ PIP_ARGS := "--no-compile \
              -t ${PIPENV_APP_BUNDLE_SOURCE_VENV}"
 
 do_compile () {
-   ${PIP_ENVARGS} ${PYTHON} -m pip install \
+   mkdir -p ${B}/pip-downloads
+
+   bbnote "Downloading pypi packages"
+
+   ${PIP_ENVARGS} ${PYTHON} -m pip download \
       -r ${B}/pypi.txt \
       ${PIP_ARGS} \
-      --no-deps
+      --no-deps \
+      --dest=${B}/pip-downloads/ \
+      -vvv
+
+   bbnote "Installing pypi packages"
+
+   ${PIP_ENVARGS} ${PYTHON} -m pip install \
+      --no-index --find-links=${B}/pip-downloads/ \
+      -r ${B}/pypi.txt \
+      -vvv
+
+   bbnote "Building and installing local packages"
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       -r ${B}/local.txt \
       ${PIP_ARGS} \
       --no-deps \
-      --use-feature=in-tree-build
+      --use-feature=in-tree-build \
+      -vvv
+
+   bbnote "Building and installing true source packages"
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       ${PIPENV_APP_BUNDLE_PROJECT_ROOT} \
       --use-feature=in-tree-build \
       --no-deps \
-      ${PIP_ARGS}
+      ${PIP_ARGS} \
+      -vvv
+
+   bbnote "Done installing python packages"
 }
 
 do_compile[vardeps] += "PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS"

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -159,7 +159,7 @@ do_compile () {
 
    ${PYTHON} -m pip install \
       -t ${B}/pip-buildenv \
-      hatchling flit flit-core setuptools setuptools-scm[toml] wheel distutils\
+      hatchling flit flit-core setuptools==65.6.3 setuptools-scm[toml]==7.1.0 wheel==0.38.4 \
 
 
    ${PIP_ENVARGS} PYTHONPATH=${B}/pip-buildenv:${PYTHONPATH} ${PYTHON} -m pip install \

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -155,16 +155,18 @@ do_compile () {
    mkdir -p ${B}/pip-downloads
 
    bbnote "Installing common build deps ahead of time"
-   ${PIP_ENVARGS} ${PYTHON} -m pip download \
+
+   ${PYTHON} -m pip download \
       --dest=${B}/pip-downloads \
       -- \
-      flit setuptools setuptools_scm[toml]
+      flit hatch setuptools setuptools_scm[toml]
 
    bbnote "Downloading pypi packages"
 
    ${PIP_ENVARGS} ${PYTHON} -m pip download \
       -r ${B}/pypi.txt \
       --no-deps \
+      --no-binary :all: \
       --dest=${B}/pip-downloads/ \
       -vvv
 

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -149,19 +149,24 @@ PIP_ARGS := "--no-compile \
              --no-binary :all: \
              --progress-bar off \
              --force-reinstall \
+             --no-deps \
              -t ${PIPENV_APP_BUNDLE_SOURCE_VENV}"
 
 do_compile () {
-   mkdir -p ${B}/pip-downloads
+   mkdir -p ${B}/pip-buildenv
 
    bbnote "Installing pypi packages"
 
-   ${PIP_ENVARGS} ${PYTHON} -m pip install \
-      --no-use-pep517 \
+   ${PYTHON} -m pip install \
+      -t ${B}/pip-buildenv \
+      hatchling flit flit-core setuptools setuptools-scm[toml] \
+
+
+   ${PIP_ENVARGS} PYTHONPATH=${B}/pip-buildenv:${PYTHONPATH} ${PYTHON} -m pip install \
       ${PIP_ARGS} \
+      --no-build-isolation \
       -r ${B}/pypi.txt \
-      --no-deps \
-      -vvv
+
 
    bbnote "Building and installing local packages"
 
@@ -169,9 +174,8 @@ do_compile () {
       -r ${B}/local.txt \
       --no-use-pep517 \
       ${PIP_ARGS} \
-      --no-deps \
       --use-feature=in-tree-build \
-      -vvv
+
 
    bbnote "Building and installing true source packages"
 
@@ -179,9 +183,8 @@ do_compile () {
       ${PIPENV_APP_BUNDLE_PROJECT_ROOT} \
       --no-use-pep517 \
       --use-feature=in-tree-build \
-      --no-deps \
       ${PIP_ARGS} \
-      -vvv
+
 
    bbnote "Done installing python packages"
 }

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -154,11 +154,16 @@ PIP_ARGS := "--no-compile \
 do_compile () {
    mkdir -p ${B}/pip-downloads
 
+   bbnote "Installing common build deps ahead of time"
+   ${PIP_ENVARGS} ${PYTHON} -m pip download \
+      --dest=${B}/pip-downloads \
+      -- \
+      flit setuptools setuptools_scm[toml]
+
    bbnote "Downloading pypi packages"
 
    ${PIP_ENVARGS} ${PYTHON} -m pip download \
       -r ${B}/pypi.txt \
-      ${PIP_ARGS} \
       --no-deps \
       --dest=${B}/pip-downloads/ \
       -vvv
@@ -167,7 +172,9 @@ do_compile () {
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       --no-index --find-links=${B}/pip-downloads/ \
+      ${PIP_ARGS} \
       -r ${B}/pypi.txt \
+      --no-deps \
       -vvv
 
    bbnote "Building and installing local packages"

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -159,7 +159,7 @@ do_compile () {
 
    ${PYTHON} -m pip install \
       -t ${B}/pip-buildenv \
-      hatchling flit flit-core setuptools setuptools-scm[toml] \
+      hatchling flit flit-core setuptools setuptools-scm[toml] wheel \
 
 
    ${PIP_ENVARGS} PYTHONPATH=${B}/pip-buildenv:${PYTHONPATH} ${PYTHON} -m pip install \

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -159,7 +159,7 @@ do_compile () {
    ${PYTHON} -m pip download \
       --dest=${B}/pip-downloads \
       -- \
-      flit hatch setuptools setuptools_scm[toml]
+      flit flit-core hatchling setuptools setuptools_scm[toml]
 
    bbnote "Downloading pypi packages"
 

--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -154,7 +154,8 @@ PIP_ARGS := "--no-compile \
 do_compile () {
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       -r ${B}/pypi.txt \
-      ${PIP_ARGS}
+      ${PIP_ARGS} \
+      --no-deps
 
    ${PIP_ENVARGS} ${PYTHON} -m pip install \
       -r ${B}/local.txt \


### PR DESCRIPTION
A recent pip/setuptools update made pep517 isolated builds the default. That's really good and I would like to use it but also it makes the builds incredibly slow: https://github.com/pypa/pip/issues/10060 We need to keep pep517 because it's what allows pyproject tomls to specify build deps, but by preinstalling those build deps and turning off build isolation we can make it fast again. This isn't a good general purpose solution and it will surely break at some point when we add some new package but we can cross that bridge when we come to it