### PR TITLE
recipes-robot/opentrons-jupyter-notebook: add env variables to fix jupyter notebook.

### DIFF
--- a/layers/meta-opentrons/classes/get_ot_system_version.bbclass
+++ b/layers/meta-opentrons/classes/get_ot_system_version.bbclass
@@ -1,0 +1,14 @@
+# helper bbclass to get the tagged version of oe-core
+
+OT_SYSTEM_VERSION=""
+
+python do_get_oe_version() {
+    from subprocess import check_output
+    version=check_output(['git', 'describe', '--tags', '--always']).decode().strip()
+    if version:
+        d.setVar("OT_SYSTEM_VERSION", version)
+}
+
+addtask do_get_oe_version after do_compile before do_install
+do_install[prefuncs] += "do_get_oe_version"
+

--- a/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
@@ -11,6 +11,8 @@ SupplementaryGroups=dialout
 StateDirectory=jupyter jupyter/notebooks jupyter/data jupyter/config ipython
 RuntimeDirectory=jupyter
 Environment=RUNNING_ON_VERDIN=true
+Environment=OT_SYSTEM_VERSION=
+Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
 Environment=JUPYTER_RUNTIME_DIR=%t/jupyter
 Environment=JUPYTER_CONFIG_DIR=%S/jupyter/config

--- a/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
@@ -11,7 +11,7 @@ SupplementaryGroups=dialout
 StateDirectory=jupyter jupyter/notebooks jupyter/data jupyter/config ipython
 RuntimeDirectory=jupyter
 Environment=RUNNING_ON_VERDIN=true
-Environment=OT_SYSTEM_VERSION=
+Environment=OT_SYSTEM_VERSION=##OT_SYSTEM_VERSION##
 Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.8/site-packages
 Environment=JUPYTER_RUNTIME_DIR=%t/jupyter

--- a/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/opentrons-jupyter-notebook.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/opentrons-jupyter-notebook.bb
@@ -20,7 +20,7 @@ do_install_append() {
         install -m 644 ${WORKDIR}/jupyter-notebook.service ${D}/${sysconfdir}/systemd/system/jupyter-notebook.service
 
 	# set the system version env variable
-	sed -i 's/OT_SYSTEM_VERSION=/OT_SYSTEM_VERSION=${OT_SYSTEM_VERSION}/' ${D}/${sysconfdir}/systemd/system/jupyter-notebook.service
+	sed -i 's/##OT_SYSTEM_VERSION##/${OT_SYSTEM_VERSION}/' ${D}/${sysconfdir}/systemd/system/jupyter-notebook.service
 }
 
 FILES_${PN} += "${sysconfdir}/jupyter/jupyter_notebook_config.py \

--- a/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/opentrons-jupyter-notebook.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/opentrons-jupyter-notebook.bb
@@ -1,4 +1,4 @@
-inherit systemd
+inherit systemd get_ot_system_version
 
 DESCRIPTION = "Jupyter Notebook service for Opentrons."
 LICENSE = "Apache-2.0"
@@ -18,6 +18,9 @@ do_install_append() {
         install -d ${D}/${sysconfdir}/systemd/system
         install -m 644 ${WORKDIR}/jupyter_notebook_config.py ${D}/${sysconfdir}/jupyter/jupyter_notebook_config.py
         install -m 644 ${WORKDIR}/jupyter-notebook.service ${D}/${sysconfdir}/systemd/system/jupyter-notebook.service
+
+	# set the system version env variable
+	sed -i 's/OT_SYSTEM_VERSION=/OT_SYSTEM_VERSION=${OT_SYSTEM_VERSION}/' ${D}/${sysconfdir}/systemd/system/jupyter-notebook.service
 }
 
 FILES_${PN} += "${sysconfdir}/jupyter/jupyter_notebook_config.py \

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -1,3 +1,5 @@
+inherit get_ot_system_version
+
 # Copyright (C) 2023 Seth Foster <seth@opentrons.com>
 # Released under the MIT License (see COPYING.MIT for the terms)
 DESCRIPTION = "installs defaults for the remote shell user environment"
@@ -6,15 +8,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 SRC_URI = "file://ot-environ.sh"
 
-OT_SYSTEM_VERSION=""
-
-python do_get_oe_version() {
-    from subprocess import check_output
-    version=check_output(['git', 'describe', '--tags', '--always']).decode().strip()
-    if version:
-        d.setVar("OT_SYSTEM_VERSION", version)
-}
-
 do_install() {
 	install -d ${D}/${sysconfdir}/profile.d/
 	install -m 0755 ${WORKDIR}/ot-environ.sh ${D}/${sysconfdir}/profile.d/ot-environ.sh
@@ -22,8 +15,5 @@ do_install() {
 	# add the openembedded version to ot-environ file
 	echo "export OT_SYSTEM_VERSION=${OT_SYSTEM_VERSION}" >> ${D}/${sysconfdir}/profile.d/ot-environ.sh
 }
-
-addtask do_get_oe_version after do_compile before do_install
-do_install[prefuncs] += "do_get_oe_version"
 
 FILES_${PN} += "${sysconfdir}/profile.d/ot-environ.sh"


### PR DESCRIPTION
# Overview

The Jupyter Notebook service did not have all the correct environment variables, so we could not get a protocol context instance. This PR adds the correct environment variables to the Jupyter Notebook systems file, since we are using the OT_SYSTEM_VERSION variable in multiple recipes we also added a helper bbclass to get this value.

Closes: [RQA-1258](https://opentrons.atlassian.net/browse/RQA-1258)

# Test plan

- [x] Install the image on the robot and make sure the jupyter notebook service starts up
- [x] Make sure we can import `opentrons.execute` from Jupyter
- [x] Make sure we can get a protocol context instance from Jupyter 
`protocol = opentrons.execute.get_protocol_api('2.15')`
- [x] Make sure we can call `procotol.home()` from jupyter and that it actually homes the gantry.


[RQA-1258]: https://opentrons.atlassian.net/browse/RQA-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ