### PR TITLE
recipes-extended/procps: Enable magic SysRq keys to debug potential kernel panics.

### DIFF
--- a/layers/meta-opentrons/recipes-extended/procps/files/95-opentrons.conf
+++ b/layers/meta-opentrons/recipes-extended/procps/files/95-opentrons.conf
@@ -1,0 +1,2 @@
+# Enables the magic SysRq key
+kernel.sysrq = 1

--- a/layers/meta-opentrons/recipes-extended/procps/procps_%.bbappend
+++ b/layers/meta-opentrons/recipes-extended/procps/procps_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_append := "${THISDIR}/files"
+
+SRC_URI += "file://95-opentrons.conf"
+
+do_install_append() {
+	install -d ${D}${sysconfdir}/sysctl.d
+	install -m 0644 ${WORKDIR}/95-opentrons.conf ${D}${sysconfdir}/sysctl.d/95-opentrons.conf
+}


### PR DESCRIPTION
# Overview

One of our robots was found unresponsive after the weekend, and could not connect over serial. We think it might be a resource allocation issue but can't verify yet, so let's enable magic SysRq keys so we can debug this when/if it happens again.

# Testing

- [x] Make sure magic keys are enabled by issuing reboot command