### PR TITLE
meta-opentrons: add linklocal config for eth0

### DIFF
--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/opentrons-init-systemconnections.service
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/opentrons-init-systemconnections.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Opentrons: Ensure system wired connections
+Before=NetworkManager.service
+Requires=basic.target
+After=basic.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+StandardOutput=journal
+ExecStart=/bin/mkdir -p /var/lib/NetworkManager/system-connections
+ExecStart=/bin/sh -c "cp /usr/share/default-connections/* /var/lib/NetworkManager/system-connections/"
+ExecStart=/bin/sh -c "chmod 600 /var/lib/NetworkManager/system-connections/*"
+
+[Install]
+WantedBy=NetworkManager.service

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/wired-linklocal.nmconnection
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/wired-linklocal.nmconnection
@@ -1,0 +1,26 @@
+# linklocal fallback wired network configs.
+# This configuration is meant to take over after dhcp fails and get a linklocal
+# connection. This connection shouldn't be edited if you want to
+# configure other things about the connection since it's in part for detecting
+# the network layout; if you know what kind of network you want to connect to,
+# just create a new connection with autoconnect-priority=2 (or higher). This
+# file will be overwritten on boot.
+
+[connection]
+id=wired-linklocal
+type=ethernet
+interface-name=eth0
+permissions=
+
+[ethernet]
+cloned-mac-address=permanent
+mac-address-blacklist=
+
+[ipv4]
+dns-search=
+method=link-local
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=link-local

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/wired.nmconnection
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/wired.nmconnection
@@ -1,0 +1,30 @@
+# wired default network. This configuration is meant to try a very few times for
+# an IP address through dhcp and then stop autoretrying if it fails so the
+# fallback can take over. This connection shouldn't be edited if you want to
+# configure other things about the connection since it's in part for detecting
+# the network layout; if you know what kind of network you want to connect to,
+# just create a new connection with autoconnect-priority>=2. This file will be
+# overwritten on boot.
+
+[connection]
+id=wired
+type=ethernet
+autoconnect-priority=1
+autoconnect-retries=1
+interface-name=eth0
+permissions=
+
+[ethernet]
+cloned-mac-address=permanent
+mac-address-blacklist=
+
+[ipv4]
+dhcp-timeout=30
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+may-fail=true

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -23,6 +23,8 @@ do_install_append() {
     install -d ${D}/usr/share/default-connections
     install -m 600 ${WORKDIR}/wired-linklocal.nmconnection ${D}/usr/share/default-connections/wired-linklocal.nmconnection
     install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/default-connections/wired.nmconnection
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/opentrons-init-systemconnections.service ${D}${systemd_system_unitdir}/opentrons-init-systemconnections.service
 
 }
 

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,11 +1,18 @@
+inherit systemd
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://system-connections-location.conf \
             file://disable-uap0.conf \
+            file://wired-linklocal.nmconnection \
+            file://wired.nmconnection \
+            file://opentrons-init-systemconnections.service\
 "
 
 FILES_${PN} += "/etc/NetworkManager/conf.d/system-connections-location.conf \
                 /etc/NetworkManager/conf.d/disable-uap0.conf \
+                ${systemd_system_unitdir}/opentrons-init-systemconnections.service \
+                /usr/share/system-connections/wired-linklocal.nmconnection \
+                /usr/share/system-connections/wired.nmconnection \
 "
 
 do_install_append() {
@@ -13,4 +20,11 @@ do_install_append() {
 	install -d ${D}/etc/NetworkManager/conf.d
 	install -m 644 ${WORKDIR}/system-connections-location.conf ${D}/etc/NetworkManager/conf.d/
 	install -m 644 ${WORKDIR}/disable-uap0.conf ${D}/etc/NetworkManager/conf.d/
+    install -d ${D}/usr/share/system-connections
+    install -m 600 ${WORKDIR}/wired-linklocal.nmconnection ${D}/usr/share/system-connections/wired-linklocal.nmconnection
+    install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/system-connections/wired.nmconnection
+
 }
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN}_append = " opentrons-init-systemconnections.service"

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -11,8 +11,8 @@ SRC_URI += "file://system-connections-location.conf \
 FILES_${PN} += "/etc/NetworkManager/conf.d/system-connections-location.conf \
                 /etc/NetworkManager/conf.d/disable-uap0.conf \
                 ${systemd_system_unitdir}/opentrons-init-systemconnections.service \
-                /usr/share/system-connections/wired-linklocal.nmconnection \
-                /usr/share/system-connections/wired.nmconnection \
+                /usr/share/default-connections/wired-linklocal.nmconnection \
+                /usr/share/default-connections/wired.nmconnection \
 "
 
 do_install_append() {
@@ -20,9 +20,9 @@ do_install_append() {
 	install -d ${D}/etc/NetworkManager/conf.d
 	install -m 644 ${WORKDIR}/system-connections-location.conf ${D}/etc/NetworkManager/conf.d/
 	install -m 644 ${WORKDIR}/disable-uap0.conf ${D}/etc/NetworkManager/conf.d/
-    install -d ${D}/usr/share/system-connections
-    install -m 600 ${WORKDIR}/wired-linklocal.nmconnection ${D}/usr/share/system-connections/wired-linklocal.nmconnection
-    install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/system-connections/wired.nmconnection
+    install -d ${D}/usr/share/default-connections
+    install -m 600 ${WORKDIR}/wired-linklocal.nmconnection ${D}/usr/share/default-connections/wired-linklocal.nmconnection
+    install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/default-connections/wired.nmconnection
 
 }
 


### PR DESCRIPTION
We need to support falling back to link-local connections for initial installs. The way you do this with network manager is to preconfigure connections for the eth0 iface, one higher-priority one that uses dhcp and can fail and one lower-priority one that uses linklocal. These need to go into /var/lib/NetworkManager/system-connections, but of course that's not on the rootfs, so they need to get copied at boot by a custom unit.

You'll know this works if you can install this build, plug it into a computer directly, and after 30 seconds you get a link local address.