### PR TITLE
meta-opentrons: allow s-d setup-js to fail

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -24,7 +24,9 @@ do_configure(){
     cd ${S}/app-shell-odd
     yarn electron-rebuild --arch=arm64
     cd ${S}
-    OPENTRONS_PROJECT=${OPENTRONS_PROJECT} make -C shared-data setup-js
+    # we removed setup-js from shared-data recently so let's allow it to fail so we
+    # can handle both the is-there and the is-not-there case
+    OPENTRONS_PROJECT=${OPENTRONS_PROJECT} make -C shared-data setup-js || true
 }
 
 do_compile(){


### PR DESCRIPTION
We recently removed setup-js from the shared-data makefile because it's not needed anymore, but the recipe for the ODD needed to know that. Temporarily just allow it to fail instead of removing it since sometimes it will be needed until we're forever done building old branches.