### PR TITLE
fix(build): Create symlink to .cache so we dont run out of space

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -38,10 +38,12 @@ export BITBAKEDIR=${THISDIR}/tools/bitbake
 mkdir -p /volumes/cache/electron
 mkdir -p /volumes/cache/yarn
 mkdir -p /volumes/cache/pip
+mkdir -p /volumes/cache/Cypress
 mkdir -p ~/.cache/
 ln -sf /volumes/cache/electron ~/.cache/electron
 ln -sf /volumes/cache/yarn ~/.cache/yarn
 ln -sf /volumes/cache/pip ~/.cache/pip
+ln -sf /volumes/cache/Cypress ~/.cache/Cypress
 
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?

--- a/start.sh
+++ b/start.sh
@@ -33,17 +33,12 @@ patch -f ./layers/meta-jupyter/conf/layer.conf ./meta-jupyter-backport.patch
 export BITBAKEDIR=${THISDIR}/tools/bitbake
 . layers/openembedded-core/oe-init-build-env ${THISDIR}/build
 
-# electron is ignoring the cache download set by the electron_config_cache env var
-# so for now lets manually create a symlink and set its download location to /volumes/cache
-mkdir -p /volumes/cache/electron
-mkdir -p /volumes/cache/yarn
-mkdir -p /volumes/cache/pip
-mkdir -p /volumes/cache/Cypress
+# Download locations are being ignored and we are running out of space, so
+# for now just create a symlink from /volumes/cache to ~/.cache which is
+# externally mounted to S3.
+mkdir -p /volumes/cache/
 mkdir -p ~/.cache/
-ln -sf /volumes/cache/electron ~/.cache/electron
-ln -sf /volumes/cache/yarn ~/.cache/yarn
-ln -sf /volumes/cache/pip ~/.cache/pip
-ln -sf /volumes/cache/Cypress ~/.cache/Cypress
+ln -sf /volumes/cache ~/.cache
 
 BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
 exit $?


### PR DESCRIPTION
Some Node packages are not using the correct cached directory for downloads, leading the docker instance to balloon in size causing the builds to fail. Instead of trying to wack-mole each new package whenever a build fails, let's symlink all of the `/volumes/cache` used by the docker instance to `~/.cache` which is externally mounted to S3 and has enough space to hold our cache.