### PR TITLE
chore: allow internal-release tags

### DIFF
--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -198,7 +198,7 @@ const VARIANT_TEST_SPECS: Array<[string, Ref, Variant]> = [
 VARIANT_TEST_SPECS.forEach(
   ([testNameFragment, testMonorepoRef, testExpectedResult]) => {
     test(`variant ${testNameFragment}`, () => {
-      expect(action.variantForRef(testMonorepoRef)).toStrictEqual(
+      expect(action.resolveBuildVariant(testMonorepoRef)).toStrictEqual(
         testExpectedResult
       )
     })

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -63,8 +63,8 @@ function latestTagPrefixFor(repo: Repo, variant: Variant): string[] {
   }
   if (variant === 'internal-release') {
     if (repo === 'monorepo') return ['refs/tags/internal@', 'refs/tags/ot3@v']
-    if (repo === 'oe-core') return ['refs/tags/internal@', 'refs/tags/v']
-    if (repo === 'ot3-firmware') return ['refs/tags/internal@', 'refs/tags/v']
+    if (repo === 'oe-core') return ['refs/tags/internal@']
+    if (repo === 'ot3-firmware') return ['refs/tags/internal@']
     throw new Error(`Unknown repo ${repo}`)
   }
   throw new Error(`Unknown variant ${variant}`)

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -177,7 +177,11 @@ async function resolveRefs(
                   `Bad response from github api for ${repoName} get tags: ${response.status}`
                 )
               }
-              return latestTag(response.data)
+              const latest = latestTag(response.data)
+              core.debug(
+                `latest tag for ${repoName} variant ${variant} is ${latest}`
+              )
+              return latest
             })
         )
       ).then(results =>

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -9787,9 +9787,9 @@ function latestTagPrefixFor(repo, variant) {
         if (repo === 'monorepo')
             return ['refs/tags/internal@', 'refs/tags/ot3@v'];
         if (repo === 'oe-core')
-            return ['refs/tags/internal@', 'refs/tags/v'];
+            return ['refs/tags/internal@'];
         if (repo === 'ot3-firmware')
-            return ['refs/tags/internal@', 'refs/tags/v'];
+            return ['refs/tags/internal@'];
         throw new Error(`Unknown repo ${repo}`);
     }
     throw new Error(`Unknown variant ${variant}`);

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -9862,7 +9862,9 @@ function resolveRefs(toAttempt, variant) {
                     if (response.status != 200) {
                         throw new Error(`Bad response from github api for ${repoName} get tags: ${response.status}`);
                     }
-                    return latestTag(response.data);
+                    const latest = latestTag(response.data);
+                    _actions_core__WEBPACK_IMPORTED_MODULE_1__.debug(`latest tag for ${repoName} variant ${variant} is ${latest}`);
+                    return latest;
                 }))).then(results => results.reduce((prev, current) => prev !== null && prev !== void 0 ? prev : current, null));
             });
             // this is a big function to be inline and untestable, but tookit doesn't export


### PR DESCRIPTION
Add support for internal-release tags on ot3-firmware and oe-core. Internal release tags on those repos are formatted as internal@version. Builds that start from internal-release tags on the monorepo or here will use internal-release tags from everything instead of release tags.