### PR TITLE
chore:  bump the pyzmq version and update the rpath patch

### DIFF
--- a/layers/meta-opentrons/recipes-devtools/python/python-pyzmq/club-rpath-out.patch
+++ b/layers/meta-opentrons/recipes-devtools/python/python-pyzmq/club-rpath-out.patch
@@ -1,13 +1,13 @@
 diff --git a/setup.py b/setup.py
-index d243eaa..98099bc 100755
+index c9ddcdd7..599b6721 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -211,8 +211,6 @@ def _add_rpath(settings, path):
+@@ -214,8 +214,6 @@ def _add_rpath(settings, path):
      """
      if sys.platform == 'darwin':
-         settings['extra_link_args'].extend(['-Wl,-rpath','-Wl,%s' % path])
+         settings['extra_link_args'].extend(['-Wl,-rpath', '-Wl,%s' % path])
 -    else:
 -        settings['runtime_library_dirs'].append(path)
  
- def settings_from_prefix(prefix=None, bundle_libzmq_dylib=False):
-     """load appropriate library/include settings from ZMQ prefix"""
+ 
+ def settings_from_prefix(prefix=None):

--- a/layers/meta-opentrons/recipes-devtools/python/python3-pyzmq_24.0.1.bb
+++ b/layers/meta-opentrons/recipes-devtools/python/python3-pyzmq_24.0.1.bb
@@ -8,8 +8,8 @@ DEPENDS = "zeromq"
 FILESEXTRAPATHS:prepend := "${THISDIR}/python-pyzmq:"
 
 SRC_URI += "file://club-rpath-out.patch"
-SRC_URI[md5sum] = "200abc1a75bdcfff7adf61304f46f55e"
-SRC_URI[sha256sum] = "296540a065c8c21b26d63e3cea2d1d57902373b16e4256afe46422691903a438"
+SRC_URI[md5sum] = "f10b7c3dee2c03557e2c5d00b73dfc7f"
+SRC_URI[sha256sum] = "216f5d7dbb67166759e59b0479bca82b8acf9bed6015b526b8eb10143fb08e77"
 
 inherit pypi pkgconfig setuptools3
 

--- a/layers/meta-opentrons/recipes-devtools/python/python3-pyzmq_24.0.1.bb
+++ b/layers/meta-opentrons/recipes-devtools/python/python3-pyzmq_24.0.1.bb
@@ -3,7 +3,9 @@ HOMEPAGE = "http://zeromq.org/bindings:python"
 LICENSE = "BSD & LGPL-3.0"
 LIC_FILES_CHKSUM = "file://COPYING.BSD;md5=11c65680f637c3df7f58bbc8d133e96e \
                     file://COPYING.LESSER;md5=12c592fa0bcfff3fb0977b066e9cb69e"
-DEPENDS = "zeromq"
+DEPENDS += "\
+    zeromq \
+    ${PYTHON_PN}-packaging"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/python-pyzmq:"
 


### PR DESCRIPTION
we need an updated pyzmq for the updated jupyter notebook