### PR TITLE
recipes-robot/opentrons-mcu-firmware: add hepa-uv firmware hex files to build.

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-mcu-firmware/opentrons-mcu-firmware.bb
@@ -71,6 +71,7 @@ FILES:${PN} += "${libdir}/firmware/head-*.hex \
                 ${libdir}/firmware/gantry-*.hex \
                 ${libdir}/firmware/gripper-*.hex \
                 ${libdir}/firmware/pipettes-*.hex \
+                ${libdir}/firmware/hepa-uv-*.hex \
                 ${libdir}/firmware/rear-panel-*.bin \
                 ${libdir}/firmware/opentrons-firmware.json \
                 /opentrons_versions/opentrons-firmware-version.json \


### PR DESCRIPTION
Fix the build by including the hepa-uv hex files now generated by the ot3-firmware repo.
[This](https://github.com/Opentrons/ot3-firmware/pull/743) other ot3-firmware change adds the hepa-uv entry to the `opentrons-manifest.json` file.