### PR TITLE
layers/meta-opentrons: fix loading screen, connections

### DIFF
--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/wired.nmconnection
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/wired.nmconnection
@@ -10,7 +10,7 @@
 id=wired
 type=ethernet
 autoconnect-priority=1
-autoconnect-retries=1
+autoconnect-retries=2
 interface-name=eth0
 permissions=
 

--- a/layers/meta-opentrons/recipes-multimedia/gstreamer-1.0/files/gstd.service
+++ b/layers/meta-opentrons/recipes-multimedia/gstreamer-1.0/files/gstd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=gstd
-After=weston@root.service
-Requires=weston@root.service
+After=weston.service
+Requires=weston.service
 Before=multi-user.target
 
 [Service]


### PR DESCRIPTION
- The loading screen service unit needs to refer to weston correctly
- the dhcp wired ethernet service needed a retry since it fails the first time