### PR TITLE
layers/meta-opentrons: add mosquitto

### DIFF
--- a/layers/meta-opentrons/recipes-connectivity/mosquitto/files/1571.patch
+++ b/layers/meta-opentrons/recipes-connectivity/mosquitto/files/1571.patch
@@ -1,0 +1,22 @@
+Upstream-Status: Submitted [https://github.com/eclipse/mosquitto/pull/1571]
+From 3fe5468f1bdca1bff1d18cf43c9e338f41aa9e32 Mon Sep 17 00:00:00 2001
+From: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
+Date: Wed, 22 Jan 2020 12:39:49 +0100
+Subject: [PATCH] Add dynamic symbols linking with cmake too
+
+Signed-off-by: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
+---
+ lib/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -94,6 +94,8 @@
+ 	OUTPUT_NAME mosquitto
+ 	VERSION ${VERSION}
+ 	SOVERSION 1
++	LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.version
++	LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/linker.version"
+ )
+ 
+ install(TARGETS libmosquitto

--- a/layers/meta-opentrons/recipes-connectivity/mosquitto/files/2894.patch
+++ b/layers/meta-opentrons/recipes-connectivity/mosquitto/files/2894.patch
@@ -1,0 +1,24 @@
+From: Joachim Zobel <jz-2017@heute-morgen.de>
+Date: Wed, 13 Sep 2023 09:55:34 +0200
+Subject: [PATCH] Link correctly with shared websockets library if needed see:
+ https://github.com/eclipse/mosquitto/pull/2751
+
+Patch contributed by Joachim Zobel <jz-2017@heute-morgen.de> and  Daniel Engberg <daniel.engberg.lists@pyret.net>
+---
+Upstream-Status: Pending
+
+ src/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9380a04..dce8313 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -200,7 +200,7 @@ if (WITH_WEBSOCKETS)
+ 			link_directories(${mosquitto_SOURCE_DIR})
+ 		endif (WIN32)
+ 	else (STATIC_WEBSOCKETS)
+-		set (MOSQ_LIBS ${MOSQ_LIBS} websockets)
++		set (MOSQ_LIBS ${MOSQ_LIBS} websockets_shared)
+ 	endif (STATIC_WEBSOCKETS)
+ endif (WITH_WEBSOCKETS)

--- a/layers/meta-opentrons/recipes-connectivity/mosquitto/files/2895.patch
+++ b/layers/meta-opentrons/recipes-connectivity/mosquitto/files/2895.patch
@@ -1,0 +1,27 @@
+From: Joachim Zobel <jz-2017@heute-morgen.de>
+Date: Wed, 13 Sep 2023 10:05:43 +0200
+Subject: [PATCH] Mosquitto now waits for network-online when starting
+ (Closes: #1036450)
+
+See: https://github.com/eclipse/mosquitto/issues/2878
+---
+Upstream-Status: Pending
+
+ service/systemd/mosquitto.service.simple | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/service/systemd/mosquitto.service.simple b/service/systemd/mosquitto.service.simple
+index 15ee0d6..c2a330b 100644
+--- a/service/systemd/mosquitto.service.simple
++++ b/service/systemd/mosquitto.service.simple
+@@ -1,8 +1,8 @@
+ [Unit]
+ Description=Mosquitto MQTT Broker
+ Documentation=man:mosquitto.conf(5) man:mosquitto(8)
+-After=network.target
+-Wants=network.target
++After=network-online.target
++Wants=network-online.target
+ 
+ [Service]
+ ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf

--- a/layers/meta-opentrons/recipes-connectivity/mosquitto/files/mosquitto.conf
+++ b/layers/meta-opentrons/recipes-connectivity/mosquitto/files/mosquitto.conf
@@ -1,0 +1,3 @@
+allow_anonymous true
+listener 1883
+protocol mqtt

--- a/layers/meta-opentrons/recipes-connectivity/mosquitto/mosquitto_2.0.18.bb
+++ b/layers/meta-opentrons/recipes-connectivity/mosquitto/mosquitto_2.0.18.bb
@@ -1,0 +1,82 @@
+inherit systemd useradd cmake pkgconfig
+
+SUMMARY = "Open source MQTT implementation"
+DESCRIPTION = "Mosquitto is an open source (Eclipse licensed) message broker \
+that implements the MQ Telemetry Transport protocol version 3.1, 3.1.1 and \
+5, providing both an MQTT broker and several command-line clients. MQTT \
+provides a lightweight method of carrying out messaging using a \
+publish/subscribe model. "
+HOMEPAGE = "http://mosquitto.org/"
+SECTION = "console/network"
+LICENSE = "EPL-2.0 | EDL-1.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ca9a8f366c6babf593e374d0d7d58749 \
+                    file://edl-v10;md5=9f6accb1afcb570f8be65039e2fcd49e \
+                    file://epl-v20;md5=2dd765ca47a05140be15ebafddbeadfe \
+                    file://NOTICE.md;md5=a7a91b4754c6f7995020d1b49bc829c6 \
+"
+DEPENDS = "uthash cjson"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "http://mosquitto.org/files/source/mosquitto-${PV}.tar.gz \
+           file://mosquitto.conf \
+           file://1571.patch \
+           file://2894.patch \
+           file://2895.patch \
+"
+
+SRC_URI[sha256sum] = "d665fe7d0032881b1371a47f34169ee4edab67903b2cd2b4c083822823f4448a"
+
+PACKAGECONFIG ??= "systemd"
+
+PACKAGECONFIG[manpages] = "-DDOCUMENTATION=ON,-DDOCUMENTATION=OFF,libxslt-native docbook-xsl-stylesheets-native"
+PACKAGECONFIG[dns-srv] = "-DWITH_SRV=ON,-DWITH_SRV=OFF,c-ares"
+PACKAGECONFIG[ssl] = "-DWITH_TLS=ON -DWITH_TLS_PSK=ON -DWITH_EC=ON,-DWITH_TLS=OFF -DWITH_TLS_PSK=OFF -DWITH_EC=OFF,openssl"
+PACKAGECONFIG[systemd] = "-DWITH_SYSTEMD=ON,-DWITH_SYSTEMD=OFF,systemd"
+PACKAGECONFIG[websockets] = "-DWITH_WEBSOCKETS=ON,-DWITH_WEBSOCKETS=OFF,libwebsockets"
+PACKAGECONFIG[dlt] = "-DWITH_DLT=ON,-DWITH_DLT=OFF,dlt-daemon"
+
+EXTRA_OECMAKE = " \
+    -DWITH_BUNDLED_DEPS=OFF \
+    -DWITH_ADNS=ON \
+"
+
+do_install:append() {
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${S}/service/systemd/mosquitto.service.notify ${D}${systemd_unitdir}/system/mosquitto.service
+    install -m 0644 ${WORKDIR}/mosquitto.conf ${D}${sysconfdir}/mosquitto/mosquitto.conf
+}
+
+PACKAGES += "libmosquitto1 libmosquittopp1 ${PN}-clients"
+
+PACKAGE_BEFORE_PN = "${PN}-examples"
+
+FILES:${PN} = "${sbindir}/mosquitto \
+               ${libdir}/mosquitto_dynamic_security.so \
+               ${sysconfdir}/mosquitto \
+               ${systemd_unitdir}/system/mosquitto.service \
+               ${sysconfdir}/mosquitto/mosquitto.conf \
+"
+
+CONFFILES:${PN} += "${sysconfdir}/mosquitto/mosquitto.conf"
+
+FILES:libmosquitto1 = "${libdir}/libmosquitto.so.*"
+
+FILES:libmosquittopp1 = "${libdir}/libmosquittopp.so.*"
+
+FILES:${PN}-clients = "${bindir}/mosquitto_pub \
+                       ${bindir}/mosquitto_sub \
+                       ${bindir}/mosquitto_rr \
+"
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "mosquitto.service"
+
+INITSCRIPT_NAME = "mosquitto"
+INITSCRIPT_PARAMS = "defaults 30"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "--system --no-create-home --shell /bin/false \
+                       --user-group mosquitto"
+
+BBCLASSEXTEND = "native"

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -55,6 +55,7 @@ IMAGE_INSTALL += " \
     python3 python3-misc python3-modules python3-jupyter \
     python3-pip \
     plymouth \
+    mosquitto \
  "
 
 # We do NOT want the toradex libusbgx packages that autoconfigure the OTG USB

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -17,7 +17,7 @@ SRC_URI:append = " file://opentrons-robot-server.service file://opentrons-ot3-ca
 
 PIPENV_APP_BUNDLE_PROJECT_ROOT = "${S}/robot-server"
 PIPENV_APP_BUNDLE_DIR = "/opt/opentrons-robot-server"
-PIPENV_APP_BUNDLE_USE_GLOBAL = "numpy systemd-python python-can wrapt pyzmq "
+PIPENV_APP_BUNDLE_USE_GLOBAL = "numpy systemd-python python-can wrapt pyzmq mosquitto"
 PIPENV_APP_BUNDLE_STRIP_HASHES = "yes"
 PIPENV_APP_BUNDLE_EXTRA_PIP_ENVARGS = "OPENTRONS_PROJECT=${OPENTRONS_PROJECT}"
 
@@ -58,6 +58,6 @@ FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-robot-server.service.d
                        ${sysconfdir}/release-notes.md \
                        "
 
-RDEPENDS:${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python python-aionotify"
+RDEPENDS:${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python python-aionotify mosquitto"
 
 inherit pipenv_app_bundle


### PR DESCRIPTION
Closes RET-1417

This PR adds support for Mosquitto, a message broker that implements MQTT.

Why Mosquitto?
- It's lightweight.
- It's open source.
- It's well-documented and supported.

See [this confluence doc](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3928621089/Notifications) for more background on the notifications work. [Here's the monorepo PR](https://github.com/Opentrons/opentrons/pull/14343). 

I'm fairly confident that the config settings are what we want, but feel free to give them a lookover [here](https://mosquitto.org/man/mosquitto-conf-5.html) if you're interested. Although we use default config values, we do need to explicitly specify these values. Otherwise, mosquitto rejects any connection attempt that isn't localhost. I didn't touch any setting related to logging/log rotation, so let me know if that needs to be done.
