### PR TITLE
layers/meta-opentrons: fix app service unit

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service.in
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Start the Opentrons Robot App
-After=weston@root.service
-Requires=weston@root.service
+After=weston.service
+Requires=weston.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
This service unit has a bad dep! And while the app still starts, weirdly enough, it also breaks devtools.