### PR TITLE
layers/meta-opentrons: xz for journald

### DIFF
--- a/layers/meta-opentrons/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,3 @@
+# xz support was present on older builds and must be present now to read journal files
+# from before the upgrade
+PACKAGECONFIG += " xz "

--- a/layers/meta-opentrons/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/systemd/systemd_%.bbappend
@@ -1,3 +1,3 @@
 # xz support was present on older builds and must be present now to read journal files
 # from before the upgrade
-PACKAGECONFIG += " xz "
+PACKAGECONFIG:append = " xz "


### PR DESCRIPTION
In the upgrade, journald appears to have lost xz support and can't read old journals anymore. This should fix that.

Closes RET-1421