### PR TITLE
layers/meta-opentrons: add boot script runner

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/opentrons-run-boot-scripts.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/opentrons-run-boot-scripts.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Opentrons: Run user-supplied boot scripts
+Requires=basic.target
+After=basic.target
+
+[Service]
+Type=oneshot
+StandardOutput=journal
+ExecStart=/bin/run-parts /var/user-packages/etc/boot.d/
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -1,4 +1,4 @@
-inherit get_ot_system_version
+inherit get_ot_system_version systemd
 
 # Copyright (C) 2023 Seth Foster <seth@opentrons.com>
 # Released under the MIT License (see COPYING.MIT for the terms)
@@ -6,11 +6,13 @@ DESCRIPTION = "installs defaults for the remote shell user environment"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-SRC_URI = "file://ot-environ.sh"
+SRC_URI = "file://ot-environ.sh file://opentrons-run-boot-scripts.service"
 
 do_install() {
 	install -d ${D}/${sysconfdir}/profile.d/
 	install -m 0755 ${WORKDIR}/ot-environ.sh ${D}/${sysconfdir}/profile.d/ot-environ.sh
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/opentrons-run-boot-scripts.service ${D}${systemd_system_unitdir}/opentrons-run-boot-scripts.service
 
 	# add the openembedded version to ot-environ file
 	echo "export OT_SYSTEM_VERSION=${OT_SYSTEM_VERSION}" >> ${D}/${sysconfdir}/profile.d/ot-environ.sh
@@ -19,4 +21,7 @@ do_install() {
 addtask do_get_oe_version after do_compile before do_install
 do_install[prefuncs] += "do_get_oe_version"
 
-FILES:${PN} += "${sysconfdir}/profile.d/ot-environ.sh"
+FILES:${PN} += " ${sysconfdir}/profile.d/ot-environ.sh ${systemd_system_unitdir}/opentrons-run-boot-scripts.service "
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "opentrons-run-boot-scripts.service"


### PR DESCRIPTION
This is on the OT-2 and we forgot about it up to now - provide a way for people to run stuff on the system if they want. They have to install manually, but by dropping executable scripts in
/var/user-packages/etc/boot.d/ the scripts should be run at boot.