### PR TITLE
layers/meta-opentrons: address robot app g2d crashes

### DIFF
--- a/layers/meta-opentrons/recipes-graphics/wayland/files/imx-nxp-bsp/increase-cma.conf
+++ b/layers/meta-opentrons/recipes-graphics/wayland/files/imx-nxp-bsp/increase-cma.conf
@@ -1,0 +1,3 @@
+# increase the amount of contiguous memory area for buffer allocations
+[Service]
+ExecStartPre=/bin/echo '671088640' > /sys/module/galcore/parameters/contiguousSize

--- a/layers/meta-opentrons/recipes-graphics/wayland/weston-init.bbappend
+++ b/layers/meta-opentrons/recipes-graphics/wayland/weston-init.bbappend
@@ -1,8 +1,12 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-SRC_URI += " file://manage-users.conf"
+SRC_URI += " file://manage-users.conf file://increase-cma.conf"
 
 do_install:append() {
     install -D -p -m0644 ${WORKDIR}/manage-users.conf ${D}${systemd_system_unitdir}/weston.service.d/manage-users.conf
+    install -D -p -m0644 ${WORKDIR}/increase-cma.conf ${D}${systemd_system_unitdir}/weston.service.d/increase-cma.conf
 }
 
-FILES:${PN} += " ${systemd_system_unitdir}/weston.service.d ${systemd_system_unitdir}/weston.service.d/manage-users.conf"
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/weston.service.d ${systemd_system_unitdir}/weston.service.d/manage-users.conf \
+    ${systemd_system_unitdir}/weston.service.d ${systemd_system_unitdir}/weston.service.d/increase-cma.conf \
+"

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service.in
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service.in
@@ -12,6 +12,7 @@ ExecStopPost=/bin/systemctl start opentrons-loading.service
 TimeoutStartSec=30
 ExitType=cgroup
 NotifyAccess=all
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It seems like occasionally weston runs out of space to get render buffers to allocate. This crashes weston and therefore crashes the ODD and therefore displays something weird and ugly because opentrons-loading can't run either.

Let's do two things to address this:
1. The ODD can autorestart, which should prevent the problem from lingering
2. We can increase the amount of contiguous memory available to ideally prevent it from happening

More info about contiguous memory on imx/galcore: https://community.nxp.com/t5/i-MX-Processors/imx8mp-How-to-resolve-weston-crash-with-g2d-alloc-alloc-memory/m-p/1535838

Closes RQA-2353