### PR TITLE
layers/meta-opentrons: various fixes for system server oem mode

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-loading.sh
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-loading.sh
@@ -15,7 +15,7 @@ trap "gstd-client pipeline_delete p; exit" SIGHUP SIGINT SIGTERM
 system_env_file="/var/lib/opentrons-system-server/system.env"
 if [ -f $system_env_file ]; then
 	echo "Found system environment file: ${system_env_file}"
-	export $(grep -v '^#' $system_env_file | xargs)
+	export $(grep -v '^#' $system_env_file | xargs | tr -d \'\")
 fi
 
 oem_mode_enabled=$OT_SYSTEM_SERVER_oem_mode_enabled
@@ -23,7 +23,7 @@ oem_mode_splash_custom=$OT_SYSTEM_SERVER_oem_mode_splash_custom
 oem_mode_splash_default="/usr/share/opentrons/oem_mode_default.png"
 opentrons_default_splash="/usr/share/opentrons/loading.mp4"
 splash_screen_path="${opentrons_default_splash}"
-PATTERN='^(True|true|1)$'
+PATTERN='(True|true|1)'
 if [[ "${oem_mode_enabled}" =~ $PATTERN ]]; then
 	echo "OEM Mode is Enabled"
 	if [ -f "${oem_mode_splash_custom}" ]; then

--- a/layers/meta-opentrons/recipes-robot/opentrons-system-server/files/opentrons-system-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-system-server/files/opentrons-system-server.service
@@ -9,6 +9,7 @@ ExecStart=python3 -m system_server
 StateDirectory=opentrons-system-server
 Environment=PYTHONPATH=/opt/opentrons-system-server:/usr/lib/python3.10/site-packages
 Environment=OT_SYSTEM_SERVER_persistence_directory=/var/lib/opentrons-system-server
+Environment=OT_SYSTEM_SERVER_dot_env_path=/var/lib/opentrons-system-server/system.env
 Restart=on-failure
 TimeoutStartSec=3min
 


### PR DESCRIPTION
A few fixes and additions for OEM Mode

- add `OT_SYSTEM_SERVER_dot_env_path` dotenv file to the systemd file for the system server
- use the linux `tr` command to strip away quotes and double quotes when parsing dotenv file
- loosen the regex when parsing `oem_mode_enabled` flag