### PR TITLE
meta-opentrons/udev-rules: add rule to opentrons-modules.rules

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/95-opentrons-modules.rules
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/95-opentrons-modules.rules
@@ -11,3 +11,6 @@ KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVen
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="4853", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker%n"
 # gen2 thermocycler on stm32:
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8d", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_thermocycler%n"
+
+# plate reader module
+KERNEL=="hidraw[0-9]*", ATTRS{idProduct}=="1199", ATTRS{idVendor}=="16d0", SYMLINK+="ot_module_absorbancereader%n"


### PR DESCRIPTION
This allows us to see the absorbance reader on the file system as an `/dev/ot_module*`