### PR TITLE
opentrons-robot-app: always restart service and force stop after 10s.

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service
@@ -15,9 +15,10 @@ ExecStart=/usr/bin/opentrons-robot-app.sh
 ExecStartPost=/bin/systemctl stop opentrons-loading.service
 ExecStopPost=/bin/systemctl start opentrons-loading.service
 TimeoutStartSec=30
+TimeoutStopSec=10
 ExitType=cgroup
 NotifyAccess=all
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Overview

While investigating an issue with the ODD, we noticed that the ODD electron app (opentrons-robot-app.service) continues to run even when the render process is killed for whatever reason. If we ever get into this state, we should quit the application so that the service exits and systemd can restart the service. This pull request ensures the service is always restarted and limits how long to wait before force-killing the process if it takes too long to restart. This PR corresponds with this monorepo pr [Opentrons/opentrons#15500](https://github.com/Opentrons/opentrons/pull/15500)

# Change log

- The `opentrons-robot-app.service` (ODD app) should always restart unless explicitly stopped or disabled.
- Let's add `TimeoutStopSec=10` so the service is forced to terminate if the process is taking too long to restart.

# Test Plan

- [x] Make sure that the opentrons-robot-app.service restarts automatically if the process is killed
- [x] Make sure that the opentrons-loading.service starts whenever the opentros-loading-app.service stops/restarts 
- [x] Make sure that the opentrons-loading.service is killed if restarting the service takes more than 10 seconds

# Risk Assessment

Low, service should now be up more frequently if it fails.