### PR TITLE
layers/meta-opentrons: binding for opentrons cli

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/opentrons_execute
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/opentrons_execute
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+export RUNNING_ON_VERDIN=1
+export OT_API_FF_enableOT3HardwareController="true"
+export PYTHONPATH=$PYTHONPATH:/opt/opentrons-robot-server
+python3 -m opentrons.execute "$@"

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/opentrons_simulate
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/files/opentrons_simulate
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+export RUNNING_ON_VERDIN=1
+export OT_API_FF_enableOT3HardwareController="true"
+export PYTHONPATH=$PYTHONPATH:/opt/opentrons-robot-server
+python3 -m opentrons.simulate "$@"

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -14,8 +14,8 @@ do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-run-boot-scripts.service ${D}${systemd_system_unitdir}/opentrons-run-boot-scripts.service
     install -d ${D}/${bindir}
-    install -m 0666 ${WORKDIR}/opentrons_simulate ${D}${bindir}/opentrons_simulate
-    install -m 0666 ${WORKDIR}/opentrons_execute ${D}${bindir}/opentrons_execute
+    install -m 0555 ${WORKDIR}/opentrons_simulate ${D}${bindir}/opentrons_simulate
+    install -m 0555 ${WORKDIR}/opentrons_execute ${D}${bindir}/opentrons_execute
 	# add the openembedded version to ot-environ file
 	echo "export OT_SYSTEM_VERSION=${OT_SYSTEM_VERSION}" >> ${D}/${sysconfdir}/profile.d/ot-environ.sh
 }

--- a/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-user-environment/opentrons-user-environment.bb
@@ -6,14 +6,16 @@ DESCRIPTION = "installs defaults for the remote shell user environment"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-SRC_URI = "file://ot-environ.sh file://opentrons-run-boot-scripts.service"
+SRC_URI = "file://ot-environ.sh file://opentrons-run-boot-scripts.service file://opentrons_simulate file://opentrons_execute"
 
 do_install() {
 	install -d ${D}/${sysconfdir}/profile.d/
 	install -m 0755 ${WORKDIR}/ot-environ.sh ${D}/${sysconfdir}/profile.d/ot-environ.sh
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-run-boot-scripts.service ${D}${systemd_system_unitdir}/opentrons-run-boot-scripts.service
-
+    install -d ${D}/${bindir}
+    install -m 0666 ${WORKDIR}/opentrons_simulate ${D}${bindir}/opentrons_simulate
+    install -m 0666 ${WORKDIR}/opentrons_execute ${D}${bindir}/opentrons_execute
 	# add the openembedded version to ot-environ file
 	echo "export OT_SYSTEM_VERSION=${OT_SYSTEM_VERSION}" >> ${D}/${sysconfdir}/profile.d/ot-environ.sh
 }
@@ -21,7 +23,7 @@ do_install() {
 addtask do_get_oe_version after do_compile before do_install
 do_install[prefuncs] += "do_get_oe_version"
 
-FILES:${PN} += " ${sysconfdir}/profile.d/ot-environ.sh ${systemd_system_unitdir}/opentrons-run-boot-scripts.service "
+FILES:${PN} += " ${sysconfdir}/profile.d/ot-environ.sh ${systemd_system_unitdir}/opentrons-run-boot-scripts.service ${bindir}/opentrons_simulate ${bindir}/opentrons_execute"
 
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "opentrons-run-boot-scripts.service"


### PR DESCRIPTION
Add explicit executable shell scripts for `opentrons_simulate` and `opentrons_execute`. 

Normally, when you install python packages that have script entrypoints, the install process will generate the scripts and put them in the appropriate place. Here, we have a separate python environment in a special directory that the system doesn't know about - it's used by setting environment variables in systemd units. That means the installation won't work. So we do it ourself here.

Closes RESC-285