### PR TITLE
opentrons-robot-server: add maximum_quick_transfer_settings to robot server service file.

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -14,6 +14,7 @@ Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.10/site-packages
 Environment=OT_ROBOT_SERVER_persistence_directory=%S/opentrons-robot-server
 Environment=OT_ROBOT_SERVER_maximum_unused_protocols=20
+Environment=OT_ROBOT_SERVER_maximum_quick_transfer_protocols=20
 Restart=on-failure
 TimeoutStartSec=10min
 


### PR DESCRIPTION
Add `maximum_quick_transfer_protocols=20` to robot server service file

Closes: [PLAT-314](https://opentrons.atlassian.net/browse/PLAT-314)

[PLAT-314]: https://opentrons.atlassian.net/browse/PLAT-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ