### PR TITLE
fix(CI): document consequences of tag refs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,13 +4,12 @@ This directory contains git workflows for building our openembedded system.
 
 The main workflow that does the build is [build-ot3-actions.yml](build-ot3-actions.yml). This workflow runs on self-hosted runners on AWS. Custom caching is used to reduce build times. [build-ot3-actions.yml](build-ot3-actions.yml) is triggered **only** by workflow_dispatch.
 
-## Builds, Triggers, and Concurrency
+## Triggers
 
-> Builds are costly and take at least an hour. We want to avoid running them unnecessarily. Soon we will move to ephemeral runners that are dynamically requested, but currently we use always on runners in EC2. This limits us to one run per "channel". Concurrency allows us to avoid stacking up builds when multiple merges or commits happen in quick succession. A concurrency group containing tags should only be initiated during the release process.
+> Builds are costly and take at least an hour. We want to avoid running them unnecessarily. Soon we will move to ephemeral runners that are dynamically requested, but currently we are limited to one run per "channel".
 
 - Builds triggered by this repository itself are controlled by [build-branches.yml](build-branches.yml)
 - <https://github.com/Opentrons/opentrons> triggers the majority of builds. The most common triggers are pushes to its `edge` branch and tagging of releases.
-  - we expect the concurrency group `edge----` to get cancelled frequently, but this makes sense as we don't need a build for every commit to edge.  Instead we will have a build finish every commit to `edge` not followed by another commit within ~1.5 hours.
 - <https://github.com/Opentrons/ot3-firmware> triggers builds on pushes to its `main` branch.
 
 ## Nuances of caching

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,15 +1,22 @@
-# Build systems for OE-core
+# Build systems for oe-core
 
 This directory contains git workflows for building our openembedded system.
 
-Buidls are done in github workflows. The main workflow that does the build is `./build-ot3-actions.yml`. This workflow runs on self-hosted runners on AWS. It does some custom caching to make the builds not take so long:
-- There is a `LOCAL_CACHE` environment variable injected that points to a directory that will be present on subsequent builds on the same runner
-- There is an `S3_CACHE_ARN` environment variable that is the ARN of an s3 bucket that can be used for caching
+The main workflow that does the build is [build-ot3-actions.yml](build-ot3-actions.yml). This workflow runs on self-hosted runners on AWS. Custom caching is used to reduce build times. [build-ot3-actions.yml](build-ot3-actions.yml) is triggered **only** by workflow_dispatch.
 
-Cache is stored on the S3 bucket as a big zip (since OE git cache needs to store empty directories and S3 doesn't do that on its own). We fetch cache before every build, and update `LOCAL_CACHE` with it. If the build succeeds, we update the zip and write it back.
+## Builds, Triggers, and Concurrency
 
-Build results get sent to an artifact bucket identified by `S3_ARTIFACT_ARN`.
+> Builds are costly and take at least an hour. We want to avoid running them unnecessarily. Soon we will move to ephemeral runners that are dynamically requested, but currently we use always on runners in EC2. This limits us to one run per "channel". Concurrency allows us to avoid stacking up builds when multiple merges or commits happen in quick succession. A concurrency group containing tags should only be initiated during the release process.
 
-We have to be a little more careful with removing working directories here than in normal github actions.
+- Builds triggered by this repository itself are controlled by [build-branches.yml](build-branches.yml)
+- <https://github.com/Opentrons/opentrons> triggers the majority of builds. The most common triggers are pushes to its `edge` branch and tagging of releases.
+  - we expect the concurrency group `edge----` to get cancelled frequently, but this makes sense as we don't need a build for every commit to edge.  Instead we will have a build finish every commit to `edge` not followed by another commit within ~1.5 hours.
+- <https://github.com/Opentrons/ot3-firmware> triggers builds on pushes to its `main` branch.
 
-The main workflow that does the build is triggered only by workflow_dispatch. This can be done manually if you want, but the intended workflow is that another github workflow in some dependent repo will specify the run.
+## Nuances of caching
+
+- There is a `LOCAL_CACHE` environment variable injected that points to a directory that will be present on subsequent builds on the same runner.
+- There is an `S3_CACHE_ARN` environment variable that is the ARN of an s3 bucket that can be used for caching.
+- Cache is stored on the S3 bucket as a big zip (since OE git cache needs to store empty directories and S3 doesn't do that on its own). We fetch cache before every build, and update `LOCAL_CACHE` with it. If the build succeeds, we update the zip and write it back.
+- Build results get sent to an artifact bucket identified by `S3_ARTIFACT_ARN`.
+- We have to be a little more careful with removing working directories here than in normal github actions.

--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -4,9 +4,9 @@ run-name: 'Starting a branch build of Flex for ${{ github.ref_name }}'
 on:
   push:
     branches:
-      - 'main'
-  pull_request:
-
+      - '*'
+    tags-ignore:
+      - '*'
 
 jobs:
   start-build:

--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -1,12 +1,12 @@
-name: 'Start an OT3 image build on a git branch'
-run-name: 'Starting a branch build of OT3 software for ${{ github.ref_name }}'
+name: 'Start a Flex image build on a git branch'
+run-name: 'Starting a branch build of Flex for ${{ github.ref_name }}'
 
 on:
   push:
     branches:
-      - '*'
-    tags-ignore:
-      - '*'
+      - 'main'
+  pull_request:
+
 
 jobs:
   start-build:

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -15,7 +15,7 @@ on:
         default: '-'
       ot3-firmware-ref:
         description: |
-          Ref of https://github.com/opentrons/ot3-firmware to build. ONLY use a tag ref if you are trying to actually release!!! It MUST be a full ref, e.g. refs/heads/main or  or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
+          Ref of https://github.com/opentrons/ot3-firmware to build. ONLY use a tag ref if you are trying to actually release!!! It MUST be a full ref, e.g. refs/heads/main or refs/tags/v52 or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
         required: false
         default: '-'
       infra-stage:

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -5,29 +5,32 @@ on:
     inputs:
       monorepo-ref:
         description: |
-          Ref of https://github.com/opentrons/opentrons to build. This MUST be a full ref, e.g. refs/heads/edge, or '-' to indicate not-specified. If not specified, will be determined from the oe-core ref if specified, and then default to edge.
+          Ref of https://github.com/opentrons/opentrons to build. ONLY use a tag ref if you are trying to actually release!!! This MUST be a full ref, e.g. refs/heads/edge or refs/tags/v7.5.0-alpha.1 or '-' to indicate not-specified. If not specified, will be determined from the oe-core ref if specified, and then default to edge.
         required: true
         default: '-'
       oe-core-ref:
         description: |
-          Ref of https://github.com/opentrons/oe-core to build. This is different from the ref specified in the github api/webUI when starting this workflow - that ref is what contains this workflow, this ref specifies what gets built. It MUST be a full ref, e.g. refs/heads/main, or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
+          Ref of https://github.com/opentrons/oe-core to build. This is different from the ref specified in the github api/webUI when starting this workflow - that ref is what contains this workflow, this ref specifies what gets built. ONLY use a tag ref if you are trying to actually release!!! It MUST be a full ref, e.g. refs/heads/main or refs/tags/v0.6.4 or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
         required: true
         default: '-'
       ot3-firmware-ref:
         description: |
-          Ref of https://github.com/opentrons/ot3-firmware to build. It MUST be a full ref, e.g. refs/heads/main, or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
+          Ref of https://github.com/opentrons/ot3-firmware to build. ONLY use a tag ref if you are trying to actually release!!! It MUST be a full ref, e.g. refs/heads/main or  or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
         required: false
         default: '-'
       infra-stage:
         description: |
-          What infra stage to run on. This should almost always be prod; staging and dev are useful when you explicitly want to test those infra stages.
+          What infra stage to run on. This should almost always be prod; dev is useful when you explicitly want to test or prod is busy.
         required: true
         type: choice
         options:
           - 'stage-prod'
-          - 'stage-staging'
           - 'stage-dev'
         default: 'stage-prod'
+
+concurrency:
+  group: '${{ inputs.monorepo-ref }}-${{ inputs.oe-core-ref }}-${{ inputs.ot3-firmware-ref }}'
+  cancel-in-progress: true
 
 jobs:
   decide-refs:

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -28,10 +28,6 @@ on:
           - 'stage-dev'
         default: 'stage-prod'
 
-concurrency:
-  group: '${{ inputs.monorepo-ref }}-${{ inputs.oe-core-ref }}-${{ inputs.ot3-firmware-ref }}'
-  cancel-in-progress: true
-
 jobs:
   decide-refs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

<https://opentrons.atlassian.net/browse/RDEVOPS-133>

- document that using tags as the ref in the workflow dispatch is for release only

### Edit - Keep all the workflow triggers the same - just document better the tag

> Changing this to handle RP events is more than I want to do right now.  Keep building on all pushes to `oe-core` 😊