### PR TITLE
recipes-bsp/u-boot: conditionally set can clock frequency based on SOM rev.

### DIFF
--- a/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -56,6 +56,18 @@ test -n ${overlays_file} || env set overlays_file "${rootfs_boot_dir}/overlays.t
 test -n ${overlays_prefix} || env set overlays_prefix "${rootfs_boot_dir}/overlays/"
 test -n ${vidargs} || env set vidargs "video=DSI-1:1024x600e"
 
+# Determine if the CAN clock speed has to be to be set 20Hz for < revE SOM boards.
+# This is done by reading the rev from the SOM eeprom (bus 0, addr 0x50), if its less than rev E
+# the 'som_can_20hz' flag is set. When the overlays (dtbo) are applied we check
+# the 'som_can_20hz' flag and the specific overlay file and set or skip it.
+# SOM serial number format in eeprom: seq num (4b) + version (3b) + rev (1b)
+env set som_can_20hz 0
+env set som_can_20hz_overlay "verdin-imx8mm_MCP2518_overlay.dtbo"
+env set som_rev_e 34  # rev E ('4' ascii or 34 dec)
+env set som_rev_addr 0 && setexpr som_rev_addr ${ramdisk_addr_r} + 0x7
+i2c dev 0 && i2c read 0x50 0x00 0x08 $ramdisk_addr_r
+itest.b *${som_rev_addr} < ${som_rev_e} && env set som_can_20hz 1
+
 # load kernel + dtb(s) + overlays from rootfs
 test ${boot_devtype} = "mmc" && env set load_cmd 'ext4load ${boot_devtype} ${root_devnum}:${root_part}'
 test ${boot_devtype} = "usb" && env set load_cmd 'load ${boot_devtype} ${boot_devnum}:${boot_part}'
@@ -116,7 +128,7 @@ then
 else
     env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
     env set set_bootcmd_dtb 'env set bootcmd_dtb "echo Loading DeviceTree: \\${rootfs_boot_dir}/\\${fdtfile}; ${load_cmd} \\${fdt_addr_r} \\${rootfs_boot_dir}/\\${fdtfile}"'
-    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \\${fdt_overlays}; do echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
+    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \${fdt_overlays}; do env set skip 0; if test \${som_can_20hz} = 1 && test \\${overlay_file} = \${som_can_20hz_overlay}; then env set skip 1; fi; test \\${skip} = 0 && echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
     env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}'
 fi
 

--- a/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -56,17 +56,17 @@ test -n ${overlays_file} || env set overlays_file "${rootfs_boot_dir}/overlays.t
 test -n ${overlays_prefix} || env set overlays_prefix "${rootfs_boot_dir}/overlays/"
 test -n ${vidargs} || env set vidargs "video=DSI-1:1024x600e"
 
-# Determine if the CAN clock speed has to be to be set 20Hz for < revE SOM boards.
-# This is done by reading the rev from the SOM eeprom (bus 0, addr 0x50), if its less than rev E
-# the 'som_can_20hz' flag is set. When the overlays (dtbo) are applied we check
-# the 'som_can_20hz' flag and the specific overlay file and set or skip it.
-# SOM serial number format in eeprom: seq num (4b) + version (3b) + rev (1b)
-env set som_can_20hz 0
-env set som_can_20hz_overlay "verdin-imx8mm_MCP2518_overlay.dtbo"
+# Determine if the CAN clock speed has to be to be set 20MHz for < revE SOM boards.
+# This is done by reading the rev from the SOM eeprom (bus 0, addr 0x50). When
+# the rev is >= than rev E (34 dec), the 'overlay_to_skip' var is set to the overlay
+# that sets the can clock to 20MHz. When we iterate over the overlays to apply,
+# we skip the overlay equal to 'overlay_to_skip' otherwise the overlay is applied.
+# SOM serial number format in eeprom: product num (4b) + version (3b) + rev (1b)
+env set overlay_to_skip ""
 env set som_rev_e 34  # rev E ('4' ascii or 34 dec)
 env set som_rev_addr 0 && setexpr som_rev_addr ${ramdisk_addr_r} + 0x7
 i2c dev 0 && i2c read 0x50 0x00 0x08 $ramdisk_addr_r
-itest.b *${som_rev_addr} < ${som_rev_e} && env set som_can_20hz 1
+itest.b *${som_rev_addr} >= ${som_rev_e} && env set overlay_to_skip "verdin-imx8mm_MCP2518_overlay.dtbo"
 
 # load kernel + dtb(s) + overlays from rootfs
 test ${boot_devtype} = "mmc" && env set load_cmd 'ext4load ${boot_devtype} ${root_devnum}:${root_part}'
@@ -128,7 +128,7 @@ then
 else
     env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
     env set set_bootcmd_dtb 'env set bootcmd_dtb "echo Loading DeviceTree: \\${rootfs_boot_dir}/\\${fdtfile}; ${load_cmd} \\${fdt_addr_r} \\${rootfs_boot_dir}/\\${fdtfile}"'
-    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \\${fdt_overlays}; do env set skip 0; if test \${som_can_20hz} = 0 && test \\${overlay_file} = \${som_can_20hz_overlay}; then env set skip 1; fi; test \\${skip} = 0 && echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
+    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \\${fdt_overlays}; do test \\${overlay_file} != \\${overlay_to_skip} && echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
     env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}'
 fi
 

--- a/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/layers/meta-opentrons/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -128,7 +128,7 @@ then
 else
     env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
     env set set_bootcmd_dtb 'env set bootcmd_dtb "echo Loading DeviceTree: \\${rootfs_boot_dir}/\\${fdtfile}; ${load_cmd} \\${fdt_addr_r} \\${rootfs_boot_dir}/\\${fdtfile}"'
-    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \${fdt_overlays}; do env set skip 0; if test \${som_can_20hz} = 1 && test \\${overlay_file} = \${som_can_20hz_overlay}; then env set skip 1; fi; test \\${skip} = 0 && echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
+    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \\${fdt_overlays}; do env set skip 0; if test \${som_can_20hz} = 0 && test \\${overlay_file} = \${som_can_20hz_overlay}; then env set skip 1; fi; test \\${skip} = 0 && echo Applying Overlay: \\${rootfs_boot_dir}/\\${overlay_file} && ${load_cmd} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
     env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}'
 fi
 


### PR DESCRIPTION
# Overview
The CAN clock frequency has changed from 20MHz to 40MHz as of Verdin iMX8M Mini [Rev E](https://developer.toradex.com/linux-bsp/application-development/peripheral-access/can-linux/#how-to-change-can-clock-source), and since we have ordered a new batch of SOMs that will most likely be Rev E we need to support this change both at the factory to produce new robots but also for already deployed robots. This pull request updates the u-boot script to conditionally apply the "verdin-imx8mm_MCP2518_overlay.dtbo" overlay based on the SOM rev.

Closes: [PLAT-464](https://opentrons.atlassian.net/browse/PLAT-464)

# Test Plan and Hands on Testing

- [x] Flash a SOM and make sure the device boots up
- [x] Flash a rev E SOM and make sure the can clock is set to 40Mhz.
- [x] Flash a rev D or lower SOM and make sure the can clock is set to 20Mhz.
- [x] Perform an OTA update on a rev E SOM and make sure the system boots and can clock stays at 40Mhz
- [x] Perform an OTA update on a < rev E SOM and make sure the system boots and CAN clock stays at 20Mhz
- [x] Make sure that the SOM can communicate with all CAN subsystems on the Flex (head, axis, gripper, etc)

# Changelog

- Conditionally apply the "verdin-imx8mm_MCP2518_overlay.dtbo" overlay for SOM revs lower than E.

# Risk assessment

High, while this won't affect devices on the field, it will affect new SOMs flashed, so we need to ensure adequate testing.

[PLAT-464]: https://opentrons.atlassian.net/browse/PLAT-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ