### PR TITLE
Fix mlan0 crash

### DIFF
--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/dispatch-bounce-mlan0.sh
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/dispatch-bounce-mlan0.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Detect when the wifi interface was downed because the driver crashed and reload it
+
+test "$NM_DISPATCHER_ACTION" = "down" || exit 0
+test "$DEVICE_IFACE" = "mlan0" || exit 0
+
+test $(nmcli dev show mlan0) -eq 0 && exit 0
+echo 'Detected mlan0 crash, unbinding/rebinding'
+
+echo 30b60000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/unbind
+echo 30b60000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/bind
+
+echo 'Restarting NetworkManager after mlan0 crash'
+systemctl restart NetworkManager

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/dispatch-bounce-mlan0.sh
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/dispatch-bounce-mlan0.sh
@@ -9,7 +9,9 @@ test $(nmcli dev show mlan0) -eq 0 && exit 0
 echo 'Detected mlan0 crash, unbinding/rebinding'
 
 echo 30b60000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/unbind
+sleep 1
 echo 30b60000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/bind
+sleep 1
 
 echo 'Restarting NetworkManager after mlan0 crash'
 systemctl restart NetworkManager

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI += "file://system-connections-location.conf \
             file://wired-linklocal.nmconnection \
             file://wired.nmconnection \
             file://opentrons-init-systemconnections.service\
+            file://dispatch-bounce-mlan0.sh \
 "
 
 FILES:${PN} += "/etc/NetworkManager/conf.d/system-connections-location.conf \
@@ -13,6 +14,7 @@ FILES:${PN} += "/etc/NetworkManager/conf.d/system-connections-location.conf \
                 ${systemd_system_unitdir}/opentrons-init-systemconnections.service \
                 /usr/share/default-connections/wired-linklocal.nmconnection \
                 /usr/share/default-connections/wired.nmconnection \
+                /etc/NetworkManager/dispatcher.d/bounce-mlan0.sh
 "
 
 do_install:append() {
@@ -25,7 +27,8 @@ do_install:append() {
     install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/default-connections/wired.nmconnection
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-init-systemconnections.service ${D}${systemd_system_unitdir}/opentrons-init-systemconnections.service
-
+    install -d ${D}/etc/NetworkManager/dispatcher.d
+    install -m 744 ${WORKDIR}/dispatch-bounce-mlan0.sh ${D}/etc/NetworkManager/dispatcher.d/bounce-mlan0.sh
 }
 
 SYSTEMD_AUTO_ENABLE = "enable"


### PR DESCRIPTION
Sometimes, the wifi adapter firmware crashes, and the device goes down. To fix (well, "fix") this, we can add a watcher script for NetworkManager's [dispatcher](https://man.archlinux.org/man/NetworkManager-dispatcher.8.en) interface, look for the down event, and [restart the bus](https://community.toradex.com/t/wifi-interface-not-appearing-on-verdin-imx8m-mini-after-resuming-from-suspension/22216/9?u=brayan.almonte) .