### PR TITLE
layers/meta-opentrons: overeager mlan0 reboot

### DIFF
--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/dispatch-bounce-mlan0.sh
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/dispatch-bounce-mlan0.sh
@@ -5,7 +5,7 @@
 test "$NM_DISPATCHER_ACTION" = "down" || exit 0
 test "$DEVICE_IFACE" = "mlan0" || exit 0
 
-test $(nmcli dev show mlan0) -eq 0 && exit 0
+nmcli dev show mlan0 && exit 0
 echo 'Detected mlan0 crash, unbinding/rebinding'
 
 echo 30b60000.mmc > /sys/bus/platform/drivers/sdhci-esdhc-imx/unbind


### PR DESCRIPTION
That was not how test works, and anyway we can just call it with normal pipe chaining.

This script would fire on any mlan0 down event, which could really mess up future interactions. Specifically, this would make the HTTP requests we use to connect to a wifi network fail, and then the robot would be connected after the interface got rebooted. Gross. Now it connects the first time.

Closes RQA-3087