### PR TITLE
meta-opentrons/opentrons-robot-server: add python3-pyusb dependency to support the Plate Reader.

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -58,6 +58,6 @@ FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-robot-server.service.d
                        ${sysconfdir}/release-notes.md \
                        "
 
-RDEPENDS:${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python python-aionotify mosquitto python-byonoy"
+RDEPENDS:${PN} += " udev python3-numpy python3-systemd nginx python-can python3-pyzmq libgpiod-python python-aionotify mosquitto python-byonoy python3-pyusb"
 
 inherit pipenv_app_bundle


### PR DESCRIPTION
# Overview

For some reason `pipenv_app_bundle.bbclass` does not automatically install pyusb from both the Opentrons/api or Opentrons/robot-server Pipfile. This causes the traceback when the Plate Reader is plugged into the Flex since we are trying to import `core.usb` provided by pyusb which is missing. If the Plate Reader is plugged in when the Flex is starting up, the traceback will cause the `OT3Controller` to fail startup, leaving the robot-server in a bad state.

So let's add the `python3-pyusb` dependency at the global level so we don't crash the Flex when the Plate Reader is plugged in.

Closes: [PLAT-470](https://opentrons.atlassian.net/browse/PLAT-470)

# Changelog

- Add python3-pyusb dependency to the `opentrons-robot-server` recipe

# Testing

- [x] Make sure the `pyusb` python3 dependency is installed under `/usr/lib/python3.10/site-packages`
- [x] Make sure we can import `core.usb` from any python3 instance on the Flex
- [x] Make sure the robot server process can start when the Plate Reader is plugged in
- [x] Make sure the Plate Reader is detected and added to the currently connected modules when plugged in.

# Risk Assessment

low, unreleased

[PLAT-470]: https://opentrons.atlassian.net/browse/PLAT-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ