### PR TITLE
meta-opentrons/systemd: add DNS + NTP servers that are reachable from China.

### DIFF
--- a/layers/meta-opentrons/recipes-core/systemd/files/dns-fallback.conf
+++ b/layers/meta-opentrons/recipes-core/systemd/files/dns-fallback.conf
@@ -1,0 +1,5 @@
+# Google DNS is not available in China so we alternative.
+
+[Resolve]
+DNS=8.8.8.8 2001:da8::666
+FallbackDNS=1.1.1.1

--- a/layers/meta-opentrons/recipes-core/systemd/files/ntp-fallback.conf
+++ b/layers/meta-opentrons/recipes-core/systemd/files/ntp-fallback.conf
@@ -1,0 +1,5 @@
+# Google NTP is not available in China so we use alternative.
+
+[Time]
+NTP=time.google.com time.cloudflare.com ntp.tencent.com
+FallbackNTP=pool.ntp.org

--- a/layers/meta-opentrons/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/systemd/systemd_%.bbappend
@@ -1,3 +1,24 @@
 # xz support was present on older builds and must be present now to read journal files
 # from before the upgrade
 PACKAGECONFIG:append = " xz "
+FILESEXTRAPATHS:append := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://dns-fallback.conf \
+    file://ntp-fallback.conf \
+"
+
+do_install:append() {
+    # Google DNS + NTP servers are not reachable from China so use alternatives.
+    install -d 0755 ${D}${sysconfdir}/systemd/resolved.conf.d
+    install -d 0755 ${D}${sysconfdir}/systemd/timesyncd.conf.d
+    install -m 0644 ${WORKDIR}/dns-fallback.conf ${D}${sysconfdir}/systemd/resolved.conf.d/
+    install -m 0644 ${WORKDIR}/ntp-fallback.conf ${D}${sysconfdir}/systemd/timesyncd.conf.d/
+}
+
+FILES:${PN} += " \
+    ${sysconfdir}/systemd/resolved.conf.d \
+    ${sysconfdir}/systemd/timesyncd.conf.d \
+    ${sysconfdir}/systemd/resolved.conf.d/ntp-fallback.conf \
+    ${sysconfdir}/systemd/timesyncd.conf.d/dns-fallback.conf \
+"


### PR DESCRIPTION
# Overview

The Flex cannot reach the Google DNS + NTP servers in the USA from within China, which causes unresolved domains and out-of-sync system time, leading to issues. So let's add a few backup DNS + NTP servers that are reachable from China so we don't run into this issue.

Closes: [PLAT-473](https://opentrons.atlassian.net/browse/PLAT-473)

# Changelog

- Add a custom list of DNS + NTP servers including ones reachable from China.

# Testing

- [x] systemd-timesyncd can sync the current datetime from one of the NTP servers
- [x] systemd-resolved can resolve domains from one of the DNS servers

[PLAT-473]: https://opentrons.atlassian.net/browse/PLAT-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ