### PR TITLE
opentrons-ot3-image.bb: add chinese language support

### DIFF
--- a/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts/44-source-han-sans-cn.conf
+++ b/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts/44-source-han-sans-cn.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
+<fontconfig>
+	<!-- 
+	    - Medium variant is used instead of Regular on Qt apps:
+		https://bugs.launchpad.net/ubuntu-font-family/+bug/744812
+		- Medium and Bold looks the same in certain applications:
+		https://bugs.launchpad.net/ubuntu/+source/gnome-specimen/+bug/813373
+	-->
+	<match target="scan">
+		<test name="fullname" compare="eq">
+			<string>Source Han Sans CN Medium</string>
+		</test>
+		<edit name="weight" mode="assign">
+			<const>demibold</const>
+		</edit>
+	</match>
+</fontconfig>

--- a/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts_2.004.bb
+++ b/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts_2.004.bb
@@ -1,0 +1,28 @@
+require ttf.inc
+
+SUMMARY = "Adobe OpenType region specific font family for Simplified Chinese"
+HOMEPAGE = "https://github.com/adobe-fonts/source-han-sans"
+LICENSE = "OFL-1.1"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=fac3a519e5e9eb96316656e0ca4f2b90"
+
+inherit allarch fontcache
+
+SRC_URI = " \
+    file://SourceHanSansCN-VF.ttf \
+    file://44-source-han-sans-cn.conf \
+"
+SRC_URI[md5sum] = "80056a18882059d0f7d5616a929ca8a8"
+SRC_URI[sha256sum] = "e7ed74bc82eddfb62bc9a09b7e850731ea40da8e8a1b530318c3fe395045ae6d"
+
+do_install() {
+    install -d ${D}${sysconfdir}/fonts/conf.d/
+    install -m 0644 ${WORKDIR}/44-source-han-sans-cn.conf ${D}${sysconfdir}/fonts/conf.d/
+
+    install -d ${D}${datadir}/fonts/
+    install -m 0644 ${WORKDIR}/SourceHanSansCN-VF.ttf ${D}${datadir}/fonts/
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/fonts \
+    ${datadir}/fonts \
+"

--- a/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts_2.004.bb
+++ b/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts_2.004.bb
@@ -1,5 +1,3 @@
-require ttf.inc
-
 SUMMARY = "Adobe OpenType region specific font family for Simplified Chinese"
 HOMEPAGE = "https://github.com/adobe-fonts/source-han-sans"
 LICENSE = "OFL-1.1"

--- a/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts_2.004.bb
+++ b/layers/meta-opentrons/recipes-graphics/ttf-fonts/source-han-sans-cn-fonts_2.004.bb
@@ -16,11 +16,12 @@ do_install() {
     install -d ${D}${sysconfdir}/fonts/conf.d/
     install -m 0644 ${WORKDIR}/44-source-han-sans-cn.conf ${D}${sysconfdir}/fonts/conf.d/
 
-    install -d ${D}${datadir}/fonts/
-    install -m 0644 ${WORKDIR}/SourceHanSansCN-VF.ttf ${D}${datadir}/fonts/
+    install -d ${D}${datadir}/fonts/ttf
+    install -m 0644 ${WORKDIR}/SourceHanSansCN-VF.ttf ${D}${datadir}/fonts/ttf/
 }
 
 FILES:${PN} = " \
     ${sysconfdir}/fonts \
     ${datadir}/fonts \
+    ${datadir}/fonts/ttf \
 "

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -14,7 +14,9 @@ DEPENDS += "rsync-native zip-native \
     "
 IMAGE_FSTYPES += "ext4.xz teziimg"
 
-IMAGE_LINGUAS = "en-us"
+IMAGE_LINGUAS = "en-us zh-cn"
+GLIBC_GENERATE_LOCALES = "zh_CN.UTF-8 en_GB.UTF-8 en_US.UTF-8"
+LOCALE_UTF8_ONLY="1"
 # Copy Licenses to image /usr/share/common-license
 COPY_LIC_MANIFEST ?= "1"
 COPY_LIC_DIRS ?= "1"

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -44,6 +44,7 @@ IMAGE_INSTALL += " \
     packagegroup-fsl-isp \
     udev-extraconf \
     v4l-utils dfu-util \
+    source-han-sans-cn-fonts \
     bash coreutils makedevs mime-support util-linux \
     timestamp-service networkmanager crda ch341ser \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \


### PR DESCRIPTION
# Overview

We are adding language localization support to the client, on the ODD we need to support the Chinese character set. This pull request adds support for that.

Closes: [PLAT-573](https://opentrons.atlassian.net/browse/PLAT-573)

# Testing

- [x] Ensure there are no invalid characters when localization is enabled and Chinese is selected.

[PLAT-573]: https://opentrons.atlassian.net/browse/PLAT-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ