### PR TITLE
c-ares: change source branch from master to main

### DIFF
--- a/layers/meta-opentrons/recipes-support/c-ares/c-ares_1.17.1.bb
+++ b/layers/meta-opentrons/recipes-support/c-ares/c-ares_1.17.1.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=fb997454c8d62aa6a47f07a8cd48b006"
 PV = "1.17.1"
 
 SRC_URI = "\
-    git://github.com/c-ares/c-ares.git;branch=master;protocol=https \
+    git://github.com/c-ares/c-ares.git;branch=main;protocol=https \
     file://cmake-install-libcares.pc.patch \
     file://0001-fix-configure-error-mv-libcares.pc.cmakein-to-libcar.patch \
 "


### PR DESCRIPTION
The [c-ares](https://github.com/c-ares/c-ares) repo changed its source branch from master to main, this pr fixes that on our end.