### PR TITLE
fix: disable software rasterizer in robot-app startup script

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.sh
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.sh
@@ -22,4 +22,5 @@ sleep 1
     --enable-features=UseOzonePlatform \
     --ozone-platform=wayland \
     --in-process-gpu \
+    --disable-software-rasterizer \
     --python.pathToPythonOverride=/usr/bin/python3\


### PR DESCRIPTION
Closes [RQA-3788](https://opentrons.atlassian.net/browse/RQA-3788)

The `opentrons-robot-app` gets stuck in a restart loop after the recent Electron upgrade due to a seg fault. The [core dump](https://github.com/user-attachments/files/18128711/opentrons-app-stack.txt) shows this is due to an interaction with wayland. Disabling the software rasterizer prevents the seg fault.

[Here is a special build](https://opentrons.slack.com/archives/C81CR4VCZ/p1734104240854619) that includes the mixpanel fix (causing an infinite spinner loop) and the new flag. The ODD now updates and boots as expected!

I've smoke tested the ODD, and there don't appear to be any unexpected animation artifacts.

Huge thanks to @sfoster1 for pairing on this one!

[RQA-3788]: https://opentrons.atlassian.net/browse/RQA-3788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ