### PR TITLE
opentrons-systemd-units: add a systemd service to clear the fontconfig cache.

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/opentrons-clear-fontconfig-cache.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/opentrons-clear-fontconfig-cache.service
@@ -1,0 +1,6 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ot-clear-fontconfig-cache
+
+[Install]
+WantedBy=basic.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-clear-fontconfig-cache
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-clear-fontconfig-cache
@@ -1,0 +1,4 @@
+#! /bin/bash
+echo "Clear Fontconfig cache."
+rm -rf /var/cache/fontconfig/*
+fc-cache -rf

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-clear-fontconfig-cache
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/files/ot-clear-fontconfig-cache
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env sh
+
 echo "Clear Fontconfig cache."
 rm -rf /var/cache/fontconfig/*
 fc-cache -rf

--- a/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/opentrons-systemd-units.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-systemd-units/opentrons-systemd-units.bb
@@ -8,26 +8,33 @@ FILESEXTRAPATHS:prepend = "${THISDIR}/files:"
 SRC_URI += "\
       file://var-log-journal.service \
       file://opentrons-commit-machine-id.service \
+      file://opentrons-clear-fontconfig-cache.service \
       file://ot-commit-machine-id \
+      file://ot-clear-fontconfig-cache \
       "
 
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} += "var-log-journal.service"
 SYSTEMD_SERVICE:${PN} += "opentrons-commit-machine-id.service"
+SYSTEMD_SERVICE:${PN} += "opentrons-clear-fontconfig-cache.service"
 SYSTEMD_PACKAGES = "${PN}"
 
 FILES:${PN} += "\
       ${systemd_system_unitdir}/var-log-journal.service \
       ${systemd_system_unitdir}/opentrons-commit-machine-id.service \
+      ${systemd_system_unitdir}/opentrons-clear-fontconfig-cache.service \
       ${bindir}/ot-commit-machine-id \
+      ${bindir}/ot-clear-fontconfig-cache \
       "
 
 do_install() {
    install -d ${D}/${systemd_system_unitdir}
-   install -m 0644 ${WORKDIR}/var-log-journal.service ${D}/${systemd_system_unitdir}/var-log-journal.service
-   install -m 0644 ${WORKDIR}/opentrons-commit-machine-id.service ${D}/${systemd_system_unitdir}/opentrons-commit-machine-id.service
+   install -m 0644 ${WORKDIR}/var-log-journal.service ${D}/${systemd_system_unitdir}/
+   install -m 0644 ${WORKDIR}/opentrons-commit-machine-id.service ${D}/${systemd_system_unitdir}/
+   install -m 0644 ${WORKDIR}/opentrons-clear-fontconfig-cache.service ${D}/${systemd_system_unitdir}/
 
    # install supporting files
    install -d ${D}/${bindir}
-   install -m 0744 ${WORKDIR}/ot-commit-machine-id ${D}/${bindir}/ot-commit-machine-id
+   install -m 0744 ${WORKDIR}/ot-commit-machine-id ${D}/${bindir}/
+   install -m 0744 ${WORKDIR}/ot-clear-fontconfig-cache ${D}/${bindir}/
 }


### PR DESCRIPTION
# Overview

The ODD did not recognize the simplified Chinese font when the system was updated from 8.2 or lower to 8.3.0, seems like something with Fontconfig caching the fonts from the previous installation was causing a problem. Clearing the Fontconfig cache fixes the issue, so let's add a `oneshot` systemd service that runs on startup and deletes all fontconfig cache in `/var/cache/fontconfig` and then rebuilds the fontcache with `fc-cache -rf` .

Closes: [RQA-3815](https://opentrons.atlassian.net/browse/RQA-3815)

# Testing

- update from 8.2 or lower to this build and make sure that Chinese characters are displayed correctly on the ODD.


[RQA-3815]: https://opentrons.atlassian.net/browse/RQA-3815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ