### PR TITLE
meta-opentrons/linux-kernel: use clone source for linux-stable-rt.

### DIFF
--- a/layers/meta-opentrons/recipes-kernel/linux/linux-toradex-mainline-rt_git.bb
+++ b/layers/meta-opentrons/recipes-kernel/linux/linux-toradex-mainline-rt_git.bb
@@ -1,0 +1,18 @@
+LINUX_VERSION ?= "6.1.120-rt47"
+require recipes-kernel/linux/linux-toradex-mainline_git.bb
+
+SUMMARY = "Toradex mainline real-time Linux kernel"
+# To build the RT kernel we use the RT kernel git repo rather than applying
+# the RT patch on top of a vanilla kernel.
+
+# LINUX_REPO = "git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git"
+# TODO: temp while git.kernel.org is fixed
+LINUX_REPO = "https://kernel.googlesource.com/pub/scm/linux/kernel/git/rt/linux-stable-rt.git"
+KBRANCH = "v6.1-rt"
+SRCREV_machine = "029f397b09cddc99b8748dc23a4c3d5a5cb1c85c"
+SRCREV_machine:use-head-next = "${AUTOREV}"
+
+SRC_URI:append = " \
+    file://preempt-rt.scc \
+    file://preempt-rt-less-latency.scc \
+"


### PR DESCRIPTION
There is a problem accessing git.kernel.org, so let's use a clone source so we can fix the builds

```
fatal: unable to access 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/': Failed to connect to git.kernel.org port 443: Connection timed out 
```

Clone: https://kernel.googlesource.com/pub/scm/linux/kernel/git/rt/linux-stable-rt.git