### PR TITLE
meta-opentrons/linux-toradex-mainline: use source clones for mainline and mainline-rt

### DIFF
--- a/layers/meta-opentrons/recipes-kernel/linux/linux-toradex-mainline-rt_git.bbappend
+++ b/layers/meta-opentrons/recipes-kernel/linux/linux-toradex-mainline-rt_git.bbappend
@@ -1,2 +1,2 @@
 LINUX_VERSION ?= "6.1.120-rt47"
-LINUX_REPO = "https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux.git"
+LINUX_REPO = "https://kernel.googlesource.com/pub/scm/linux/kernel/git/rt/linux-stable-rt.git"

--- a/layers/meta-opentrons/recipes-kernel/linux/linux-toradex-mainline_git.bbappend
+++ b/layers/meta-opentrons/recipes-kernel/linux/linux-toradex-mainline_git.bbappend
@@ -1,0 +1,1 @@
+LINUX_REPO = "https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux.git"


### PR DESCRIPTION
# Overview

The previous TWO [Opentrons/oe-core#190](https://github.com/Opentrons/oe-core/pull/190) and [Opentrons/oe-core#191](https://github.com/Opentrons/oe-core/pull/191) PRs did not fix the unreachable git.kernel.org source issue for out internal release builds.

1. Unfortunately, in PR#190, this was hidden behind the fact that our [build](https://github.com/Opentrons/oe-core/actions/runs/13553224868) passed because the download/sstatecache/git were cached in S3. After manually cleaning the cache in S3 and EC2 action runner and re-running the build, it exposed the failed recipe, which this pull request should fix.
2. Unfortunately, in PR#191, only linux-toradex-mainline was fixed even though again our test builds passed

This pull request fixes both `linux-toradex-mainline` AND `linux-toradex-mainline-rt` to use clone sources of the kernel.

# Testing

- [This](https://github.com/Opentrons/oe-core/actions/runs/13596570859/job/38014732903) refs/tags/ot3@2.4.0-alpha.3 builds were failing before and it should pass now.