### PR TITLE
recipes-robot/systemd: reduce the SyncIntervalSec from 5m to 1s to reduce memory usage.

### DIFF
--- a/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
+++ b/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
@@ -1,4 +1,5 @@
 [Journal]
 Storage=persistent
 ForwardToSyslog=no
+SyncIntervalSec=1m
 MaxLevelStore=debug

--- a/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
+++ b/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
@@ -1,5 +1,5 @@
 [Journal]
 Storage=persistent
 ForwardToSyslog=no
-SyncIntervalSec=1m
+SyncIntervalSec=1s
 MaxLevelStore=debug


### PR DESCRIPTION
This https://github.com/Opentrons/opentrons/issues/18034 bug identified some performance issues with the Flex robot, particularly with journal logging affecting the robot-server and robot-app processes. This pull request reduces the SyncIntervalSec from 5m to 1s to reduce the memory footprint from the logs before they are written to disk.