### PR TITLE
classes/pipenv_app_bundle: pin build deps

### DIFF
--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -163,13 +163,15 @@ do_compile () {
 
    ${PYTHON} -m pip install \
       -t ${B}/pip-buildenv \
-      hatchling hatch-vcs hatch-fancy-pypi-readme \
-      flit flit-core flit_scm \
-      setuptools==65.6.3 setuptools-scm[toml]==7.1.0 \
+      hatchling==1.27.0 hatch-vcs==0.5.0 hatch-fancy-pypi-readme==25.1.0 \
+      flit==3.12.0 flit-core==3.12.0 flit-scm==1.7.0 \
+      setuptools==65.6.3 setuptools-scm[toml]==8.2.0 \
       wheel==0.38.4 \
-      expandvars \
-      cython \
-      setuptools_rust \
+      expandvars==1.0.0 \
+      cython==3.1.1 \
+      setuptools_rust==1.11.1 \
+      typing-extensions==4.13.2 \
+
 
 
    PATH=${B}/pip-buildenv/bin/:${PATH} ${PIP_ENVARGS} PYTHONPATH=${B}/pip-buildenv:${PYTHONPATH} ${PYTHON} -m pip install \


### PR DESCRIPTION
A recent typing-extensions release seems to have broken pydantic-core's build on 3.10; pin that so it doesn't happen, and pin all the other build deps so it doesn't keep happening.

This is the same as #199 but into main so edge builds don't break so much