### PR TITLE
chore: release->main for 8.4.1

### DIFF
--- a/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/pipenv_app_bundle.bbclass
@@ -163,13 +163,15 @@ do_compile () {
 
    ${PYTHON} -m pip install \
       -t ${B}/pip-buildenv \
-      hatchling hatch-vcs hatch-fancy-pypi-readme \
-      flit flit-core flit_scm \
-      setuptools==65.6.3 setuptools-scm[toml]==7.1.0 \
+      hatchling==1.27.0 hatch-vcs==0.5.0 hatch-fancy-pypi-readme==25.1.0 \
+      flit==3.12.0 flit-core==3.12.0 flit-scm==1.7.0 \
+      setuptools==65.6.3 setuptools-scm[toml]==8.2.0 \
       wheel==0.38.4 \
-      expandvars \
-      cython \
-      setuptools_rust \
+      expandvars==1.0.0 \
+      cython==3.1.1 \
+      setuptools_rust==1.11.1 \
+      typing-extensions==4.13.2 \
+
 
 
    PATH=${B}/pip-buildenv/bin/:${PATH} ${PIP_ENVARGS} PYTHONPATH=${B}/pip-buildenv:${PYTHONPATH} ${PYTHON} -m pip install \


### PR DESCRIPTION
Small change, but we just updated release so we should tie it back. I will be fixing these merge conflicts by taking main unconditionally, I just want the git graph to flow back in.