### PR TITLE
weston: increase galcore cma to fix g2d_alloc

### DIFF
--- a/layers/meta-opentrons/recipes-graphics/wayland/files/imx-nxp-bsp/increase-cma.conf
+++ b/layers/meta-opentrons/recipes-graphics/wayland/files/imx-nxp-bsp/increase-cma.conf
@@ -1,3 +1,3 @@
 # increase the amount of contiguous memory area for buffer allocations
 [Service]
-ExecStartPre=/bin/echo '671088640' > /sys/module/galcore/parameters/contiguousSize
+ExecStartPre=/usr/bin/increase-cma.sh 268435456

--- a/layers/meta-opentrons/recipes-graphics/wayland/weston-init.bbappend
+++ b/layers/meta-opentrons/recipes-graphics/wayland/weston-init.bbappend
@@ -4,9 +4,11 @@ SRC_URI += " file://manage-users.conf file://increase-cma.conf"
 do_install:append() {
     install -D -p -m0644 ${WORKDIR}/manage-users.conf ${D}${systemd_system_unitdir}/weston.service.d/manage-users.conf
     install -D -p -m0644 ${WORKDIR}/increase-cma.conf ${D}${systemd_system_unitdir}/weston.service.d/increase-cma.conf
+    install -D -p -m0744 ${WORKDIR}/increase-cma.sh ${D}${bindir}/increase-cma.sh
 }
 
 FILES:${PN} += " \
     ${systemd_system_unitdir}/weston.service.d ${systemd_system_unitdir}/weston.service.d/manage-users.conf \
     ${systemd_system_unitdir}/weston.service.d ${systemd_system_unitdir}/weston.service.d/increase-cma.conf \
+    ${bindir}/increase-cma.sh \
 "


### PR DESCRIPTION
We were theoretically increasing the contiguous memory used by the galcore gpu driver, except that you can't use shell pipelines in systemd unit directives, so this was just printing the literal string "/bin/echo '671088640' > /sys/module/galcore/parameters/contiguousSize" to the unit file's standard out. Whoops!

Instead, use a little shell script that will echo the thing we want to the place we want. I don't know if there's a better way to do this.

Closes RQA-4285