### PR TITLE
fix(ci): CONNECTIVITY_CHECK_URIS added to local.conf in CI

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -124,6 +124,7 @@ jobs:
           echo 'OT_BUILD_TYPE = "${{needs.decide-refs.outputs.build-type}}"' >> ./build/conf/local.conf
           echo 'YARN_CACHE_DIR = "/volumes/cache/yarn"' >> ./build/conf/local.conf
           echo 'ELECTRON_CACHE_DIR = "/volumes/cache/electron"' >> ./build/conf/local.conf
+          echo 'CONNECTIVITY_CHECK_URIS = "https://www.yoctoproject.org/connectivity.html"' >> ./build/conf/local.conf
           cd ..
       - name: Apply internal-release variant CI config overrides
         if: needs.decide-refs.outputs.variant == 'internal-release'


### PR DESCRIPTION
## Looking to fix this error
https://github.com/Opentrons/oe-core/actions/runs/17282438606/job/49107012357#step:14:131
```shell
+ BB_NUMBER_THREADS=32
+ bitbake opentrons-ot3-image --runall=fetch
ERROR:  OE-core's config sanity checker detected a potential misconfiguration.
    Either fix the cause of this error or at your own risk disable the checker (see sanity.conf).
    Following is the list of potential problems / advisories:

    Fetcher failure for URL: 'https://yoctoproject.org/connectivity.html'. URL https://yoctoproject.org/connectivity.html doesn't work.
    Please ensure your host's network is configured correctly.
    Please ensure CONNECTIVITY_CHECK_URIS is correct and specified URIs are available.
    If your ISP or network is blocking the above URL,
    try with another domain name, for example by setting:
    CONNECTIVITY_CHECK_URIS = "https://www.example.com/"    You could also set BB_NO_NETWORK = "1" to disable network
    access if all required sources are on local disk.
```

### One issue may be...
`https://yoctoproject.org/connectivity.html` actually 301 redirects to `https://www.yoctoproject.org/connectivity.html`
but that seemed to happen in like April 2025?

### Another issue may be...

```shell
echo | openssl s_client -showcerts -servername yoctoproject.org -connect yoctoproject.org:443 2>/dev/null \
  | openssl x509 -noout -text
```
shows new certs so we also need to clear our docker cache?
