### PR TITLE
meta-opentrons: remove sentry cli before pack

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -47,8 +47,8 @@ do_compile(){
 
     cd ${S}/app-shell-odd
 
-   # Remove incompatible Sentry CLI binaries that cause objcopy failures
-   find -path "*/node_modules/@sentry/cli-*/bin/*" -type f -delete
+    # Remove incompatible Sentry CLI binaries that cause objcopy failures
+    find -path "*/node_modules/@sentry/cli-*/bin/*" -type f -delete
 
     OT_BUILD_TARGET="${OT_BUILD_TARGET}" \
     OT_SENTRY_AUTH_TOKEN="${OT_SENTRY_AUTH_TOKEN_OE_CORE}" \


### PR DESCRIPTION
If you remove the sentry cli binaries (that are incompatible with our arch) in fakeroot from the install dir, then you actually invalidate the asar, which has the entries for everything in app.asar.unpacked as well as the stuff in app.asar in its registry so it can present them seamlessly. Instead, remove them from the "source" node_modules before we pack the app so they just never get packed in the first place.