### PR TITLE
fix(ci): use variable for SLACK_WEBHOOK_URL_TAGGED instead of secret

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -445,7 +445,7 @@ jobs:
         with:
           status: "success"
           workflow_name: "Build Flex image on github workflows"
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_TAGGED }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL_TAGGED }}
           console_url: ${{ needs.run-build.outputs.console_url }}
           system_url: ${{ needs.run-build.outputs.system_url }}
           fullimage_url: ${{ needs.run-build.outputs.fullimage_url }}
@@ -468,7 +468,7 @@ jobs:
         with:
           status: "failure"
           workflow_name: "Build Flex image on github workflows"
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_TAGGED }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL_TAGGED }}
           console_url: ${{ needs.run-build.outputs.console_url }}
           system_url: ${{ needs.run-build.outputs.system_url }}
           fullimage_url: ${{ needs.run-build.outputs.fullimage_url }}


### PR DESCRIPTION
Read tagged Slack webhook URL from vars instead of secrets so it can be managed as a repository variable.