### PR TITLE
layers/meta-opentrons: map key-server uris

### DIFF
--- a/layers/meta-opentrons/recipes-httpd/nginx/files/nginx-http.conf
+++ b/layers/meta-opentrons/recipes-httpd/nginx/files/nginx-http.conf
@@ -81,7 +81,13 @@ http {
             root /var/www/localhost/html/stream;                               
             add_header Cache-Control no-cache;                                 
             add_header Access-Control-Allow-Origin *;                          
-        }  
+        }
+
+        location /keys/external {
+            proxy_http_version 1.1;
+            proxy_read_timeout 1h;
+            proxy_pass http://unix:/run/opentrons-key-server.sock;
+        }
     }
 }
 rtmp {

--- a/layers/meta-opentrons/recipes-httpd/nginx/files/nginx-https.conf
+++ b/layers/meta-opentrons/recipes-httpd/nginx/files/nginx-https.conf
@@ -82,5 +82,11 @@ http {
             proxy_read_timeout 1h;
             proxy_pass http://unix:/run/opentrons-auth-server.sock;
         }
+
+        location /keys/external {
+            proxy_http_version 1.1;
+            proxy_read_timeout 1h;
+            proxy_pass http://unix:/run/opentrons-key-server.sock;
+        }
     }
 }


### PR DESCRIPTION
We'll expose a /keys/external subtree here, since there's some things only the ODD and other servers should be able to access that we'll serve on /keys/internal and require direct access to the socket for.

We'll test this by putting it (and the equivalent on the python side) onto a robot and running some requests:

- [x] `curl http://robotip:31950/keys/external/ca/encryptedCerts` gets encrypted certs
- [x] `curl https://robotip:32313/keys/external/ca/encryptedCerts` gets the same ones
- [x] `curl http://robotip:31950/keys/external/ca/plaintextCerts` gets unencrypted certs
- [x] `curl https://robotip:32313/keys/external/ca/plaintextCerts` gets the same ones
- [x] ssh into the robot and `curl --unix-socket /run/opentrons-key-server.socket /keys/internal/ca/password` gets a cool password

Closes EXEC-2445