### PR TITLE
layers/meta-opentrons: Configure opentrons-auth-server persistence directory

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
@@ -9,7 +9,7 @@ NotifyAccess=all
 ExecStart=python3 -m auth_server --uds /run/opentrons-auth-server.sock
 StateDirectory=opentrons-auth-server
 Environment=PYTHONPATH=/opt/opentrons-auth-server
-Environment=OT_SYSTEM_SERVER_persistence_directory=/var/lib/opentrons-system-server
+Environment=OT_AUTH_SERVER_persistence_directory=/var/lib/opentrons-auth-server
 Restart=on-failure
 TimeoutStartSec=3min
 

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
@@ -9,6 +9,7 @@ NotifyAccess=all
 ExecStart=python3 -m auth_server --uds /run/opentrons-auth-server.sock
 StateDirectory=opentrons-auth-server
 Environment=PYTHONPATH=/opt/opentrons-auth-server
+Environment=OT_SYSTEM_SERVER_persistence_directory=/var/lib/opentrons-system-server
 Restart=on-failure
 TimeoutStartSec=3min
 


### PR DESCRIPTION
It looks like we (I) just forgot to configure this, so opentrons-auth-server was using a temp directory each boot, so settings like `accessControlEnabled` weren't persisting across boots.