### PR TITLE
opentrons-robot-app: fix pnpm setup problems

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -20,8 +20,10 @@ do_configure(){
 
     export CI=true
     pnpm install
+    cd ${S}/js-package-testing
+    pnpm install
     cd ${S}/app-shell-odd
-    pnpm exec -- electron-rebuild --arch=arm64
+    pnpm exec electron-rebuild --arch=arm64
     cd ${S}
     # we removed setup-js from shared-data recently so let's allow it to fail so we
     # can handle both the is-there and the is-not-there case

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -21,7 +21,7 @@ do_configure(){
     export CI=true
     pnpm install
     cd ${S}/js-package-testing
-    pnpm install
+    make setup
     cd ${S}/app-shell-odd
     pnpm exec electron-rebuild --arch=arm64
     cd ${S}

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -21,7 +21,7 @@ do_configure(){
     export CI=true
     pnpm install
     cd ${S}/app-shell-odd
-    pnpm rebuild --arch=arm64
+    pnpm exec -- electron-rebuild --arch=arm64
     cd ${S}
     # we removed setup-js from shared-data recently so let's allow it to fail so we
     # can handle both the is-there and the is-not-there case

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/opentrons-robot-app.bb
@@ -21,7 +21,7 @@ do_configure(){
     export CI=true
     pnpm install
     cd ${S}/app-shell-odd
-    pnpm exec electron-rebuild --arch=arm64
+    pnpm rebuild --arch=arm64
     cd ${S}
     # we removed setup-js from shared-data recently so let's allow it to fail so we
     # can handle both the is-there and the is-not-there case


### PR DESCRIPTION
Our stack requires js-package-testing to be set up now because when pnpm invokes electron-rebuild it does so on _all_ the node_modules including js-package-testing, even though it's not part of the pnpm workspaces.