### PR TITLE
fix(ci): permission issues with build caches

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -460,6 +460,12 @@ jobs:
           tmp_mount="/tmp:rw,exec"
           echo "docker run --rm --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image --runall=fetch"
           docker run --rm --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image --runall=fetch
+      - name: Reset opentrons-ot3-image workdir before full build
+        shell: bash
+        run: |
+          # Pseudo can abort on inode/path mismatch in this recipe's stale workdir.
+          # Reset only this recipe's tmp/work subtree between fetch and full build.
+          rm -rf oe-core/build/tmp/work/*/opentrons-ot3-image
       - name: Build image
         run: |
           here=$(pwd)

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -450,23 +450,7 @@ jobs:
                   echo "Cleaned up old download files"
               fi
           fi
-      - name: Download sources
-        run: |
-          here=$(pwd)
-          oe_mount="type=bind,src=$here/oe-core,dst=/volumes/oe-core,consistency=delegated"
-          monorepo_mount="type=bind,src=$here/opentrons,dst=/volumes/opentrons,consistency=delegated"
-          ot3_firmware_mount="type=bind,src=$here/ot3-firmware,dst=/volumes/ot3-firmware,consistency=delegated"
-          cache_mount="type=bind,src=${LOCAL_CACHE:-./cache},dst=/volumes/cache,consistency=delegated"
-          tmp_mount="/tmp:rw,exec"
-          echo "docker run --rm --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image --runall=fetch"
-          docker run --rm --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image --runall=fetch
-      - name: Reset opentrons-ot3-image workdir before full build
-        shell: bash
-        run: |
-          # Pseudo can abort on inode/path mismatch in this recipe's stale workdir.
-          # Reset only this recipe's tmp/work subtree between fetch and full build.
-          rm -rf oe-core/build/tmp/work/*/opentrons-ot3-image
-      - name: Build image
+      - name: Fetch sources and build image
         run: |
           here=$(pwd)
           oe_mount="type=bind,src=$here/oe-core,dst=/volumes/oe-core,consistency=delegated"
@@ -475,8 +459,10 @@ jobs:
           cache_mount="type=bind,src=${LOCAL_CACHE:-./cache},dst=/volumes/cache,consistency=delegated"
           sudo mount -o remount,exec /tmp
           tmp_mount="/tmp:rw,exec"
-          echo "docker run --rm --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image"
-          docker run --rm --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image
+          # One container: fetch then full build (start.sh). Avoids a second start.sh chown/tmp pass
+          # between separate docker runs, which triggers pseudo inode aborts on do_create_tezi_ot3.
+          echo "docker run --rm -e OE_CI_FETCH_THEN_BUILD=1 --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image"
+          docker run --rm -e OE_CI_FETCH_THEN_BUILD=1 --mount $oe_mount --mount $monorepo_mount --mount $ot3_firmware_mount --mount $cache_mount --tmpfs $tmp_mount ot3-image:latest opentrons-ot3-image
       - name: Prune images
         if: always()
         run: docker image prune -af

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -339,7 +339,14 @@ jobs:
           cd oe-core
           tmp_dir=$(mktemp -d -t ci-XXXXXXX)
           cp start.sh $tmp_dir/
-          docker build -f ./Dockerfile --tag "ot3-image:latest" $tmp_dir
+          # Must match host runner uid/gid so bind-mounted oe-core/cache are writable (see Dockerfile).
+          # Defaults in Dockerfile are 1001:1001; ec2-user is often 1000 — without this, cleanup/gather hit Permission denied.
+          docker build -f ./Dockerfile \
+            --build-arg "username=$(whoami)" \
+            --build-arg "host_uid=$(id -u)" \
+            --build-arg "host_gid=$(id -g)" \
+            --tag "ot3-image:latest" \
+            $tmp_dir
           cd ..
       - name: Apply unconditional CI config overrides
         run: |
@@ -598,8 +605,10 @@ jobs:
       - name: Remove build data
         if: always()
         continue-on-error: true
+        shell: bash
         run: |
-          rm -rf ./*
+          # Docker/BitBake leaves root-owned files in checked-out trees; plain rm fails as the runner user.
+          sudo find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
       - name: Remove poisoned cache
         if: ${{ failure() }}
         shell: bash

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -599,8 +599,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          # Docker/BitBake leaves root-owned files in checked-out trees; plain rm fails as the runner user.
-          sudo find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+          find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
       - name: Remove poisoned cache
         if: ${{ failure() }}
         shell: bash

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -493,6 +493,10 @@ jobs:
         run: |
           _oe_build=$(pwd)/oe-core/build
           echo "found build dir at ${_oe_build}"
+          # Docker/BitBake may leave root-owned files in the bind-mounted build tree.
+          if [ -d "${_oe_build}" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "${_oe_build}"
+          fi
           _artifact_root=${_oe_build}/deploy
           _artifact_unversioned_subdir=opentrons
           _artifact_s3=${_artifact_root}/${_artifact_unversioned_subdir}
@@ -604,7 +608,8 @@ jobs:
           cachedir="${LOCAL_CACHE:-./cache}"
           if [ -d "$cachedir" ]; then
             sudo chown -R "$(id -u):$(id -g)" "$cachedir"
-            rm -rf "${cachedir}/"*
+            # Some cache entries can remain undeletable by the runner user; remove as root.
+            sudo rm -rf "${cachedir}/"* "${cachedir}"/.[!.]* "${cachedir}"/..?* 2>/dev/null || true
           fi
   notify-tagged-success:
     name: "Notify Tagged Build Success"

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -494,7 +494,7 @@ jobs:
           echo "found build dir at ${_oe_build}"
           # Docker/BitBake may leave root-owned files in the bind-mounted build tree.
           if [ -d "${_oe_build}" ]; then
-            sudo chown -R "$(id -u):$(id -g)" "${_oe_build}"
+            chown -R "$(id -u):$(id -g)" "${_oe_build}"
           fi
           _artifact_root=${_oe_build}/deploy
           _artifact_unversioned_subdir=opentrons
@@ -599,7 +599,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+          sudo find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
       - name: Remove poisoned cache
         if: ${{ failure() }}
         shell: bash

--- a/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
+++ b/layers/meta-opentrons/recipes-images/images/opentrons-ot3-image.bb
@@ -287,7 +287,10 @@ python do_create_tezi_manifest(){
 }
 
 # create the tezi ot3 image
-fakeroot do_create_tezi_ot3() {
+# Not fakeroot: this task only runs tar on DEPLOY_DIR_IMAGE. Marking it fakeroot makes
+# BitBake run pre-task cleanup (e.g. rm -rf .../image-json from image_type_tezi) under
+# pseudo, which can SIGABRT with inode/path mismatch on bind-mounted CI workspaces.
+do_create_tezi_ot3() {
     tar --xattrs --xattrs-include=* --numeric-owner --transform \
     's,^,${TEZI_IMAGE_NAME}-Tezi_${TEZI_VERSION}/,' -chf  \
     ${DEPLOY_DIR_IMAGE}/${TEZI_IMAGE_NAME}-Tezi_${TEZI_VERSION}.tar -C \
@@ -325,7 +328,6 @@ do_create_dummy_bootloader() {
 do_create_filesystem[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 do_create_tezi_manifest[prefuncs] += "do_image_teziimg"
 
-do_create_tezi_ot3[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 do_create_tezi_ot3[prefuncs] += "do_image_teziimg do_create_filesystem"
 do_image_wic[prefuncs] += "do_create_dummy_bootloader"
 

--- a/start.sh
+++ b/start.sh
@@ -25,7 +25,16 @@ shift
 
 trap cleanup EXIT
 
-sudo chown -hR $USER_NAME:$USER_NAME /volumes && chmod -R ug+rw /volumes
+# Writable bind mounts for the build user. Do **not** recurse into oe-core/build/tmp:
+# that tree is managed by BitBake/pseudo; blanket chown corrupts pseudo's inode DB
+# (e.g. Tezi do_create_tezi_ot3 failing on rm image-json).
+OE_VOL="/volumes/oe-core"
+sudo chown -hR "${USER_NAME}:${USER_NAME}" /volumes/cache /volumes/opentrons /volumes/ot3-firmware 2>/dev/null || true
+sudo chmod -R ug+rw /volumes/cache /volumes/opentrons /volumes/ot3-firmware 2>/dev/null || true
+if [ -d "${OE_VOL}" ]; then
+  sudo find "${OE_VOL}" -path "${OE_VOL}/build/tmp" -prune -o -exec chown -h "${USER_NAME}:${USER_NAME}" {} +
+  sudo find "${OE_VOL}" -path "${OE_VOL}/build/tmp" -prune -o -exec chmod ug+rw {} +
+fi
 
 pushd ${THISDIR}
 
@@ -59,5 +68,11 @@ if [ ! -e ~/.cache ]; then
     ln -sf /volumes/cache ~/.cache
 fi
 
-BB_NUMBER_THREADS=$(nproc) bitbake ${TARGET} "$@"
+# CI: run fetch and full image in one container so a second start.sh pass never chowns tmp/work
+# between BitBake phases (avoids pseudo inode/path abort on Tezi tasks).
+if [ "${OE_CI_FETCH_THEN_BUILD:-}" = "1" ]; then
+  BB_NUMBER_THREADS=$(nproc) bitbake "${TARGET}" --runall=fetch || exit $?
+fi
+
+BB_NUMBER_THREADS=$(nproc) bitbake "${TARGET}" "$@"
 exit $?


### PR DESCRIPTION
Fixes permission failures on self-hosted runners when gathering artifacts, clearing the workspace, and wiping cache after failed builds.

Changes
* Docker image build: Pass --build-arg host_uid, host_gid, and username from the runner so bind-mounted oe-core and cache are written as the same UID as the job user (matches ot3Image.sh and the Dockerfile intent). Avoids relying on UID 1001 matching the runner (e.g. ec2-user as 1000).
* Gather results: chown the oe-core/build tree to the runner before creating deploy/opentrons and copying artifacts, for any leftover root- or wrong-UID files.
* Remove build data: Remove workspace children with sudo so root- or foreign-UID trees from Docker can still be deleted.
* Remove poisoned cache: After chown, run cache deletion with sudo so stubborn cache entries still clear.
