### PR TITLE
recipes-robot/systemd: Reduce eMMC wear with optimized journald and fstab settings

### DIFF
--- a/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
+++ b/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
@@ -14,5 +14,5 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 /userfs/media            /media                none       defaults,bind,noatime,nodiratime,commit=10         0  0
 /userfs/var              /var                  none       defaults,bind,noatime,nodiratime,commit=10         0  0
 /userfs/var/mnt          /mnt                  none       defaults,bind,noatime,nodiratime,commit=10         0  0
-/userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail  0  0
-/userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail  0  0
+/userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail,noatime,nodiratime,commit=10  0  0
+/userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail,noatime,nodiratime,commit=10  0  0

--- a/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
+++ b/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
@@ -8,11 +8,11 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 #/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
 
 # opentrons custom mount points
-/dev/mmcblk0p4           /userfs               auto       rw,x-systemd.growfs   0  2
-/userfs/home             /home                 none       defaults,bind         0  0
-/userfs/data             /data                 none       defaults,bind         0  0
-/userfs/media            /media                none       defaults,bind         0  0
-/userfs/var              /var                  none       defaults,bind         0  0
-/userfs/var/mnt          /mnt                  none       defaults,bind         0  0
+/dev/mmcblk0p4           /userfs               auto       noatime,nodiratime,commit=10,rw,x-systemd.growfs   0  2
+/userfs/home             /home                 none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/data             /data                 none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/media            /media                none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/var              /var                  none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/var/mnt          /mnt                  none       defaults,bind,noatime,nodiratime,commit=10         0  0
 /userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail  0  0
 /userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail  0  0

--- a/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
+++ b/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
@@ -1,8 +1,5 @@
 [Journal]
-Storage=volatile
+Storage=persistent
 ForwardToSyslog=no
-SyncIntervalSec=10m
-RuntimeMaxUse=64M
-RateLimitIntervalSec=30s
-RateLimitBurst=2500
+SyncIntervalSec=30s
 MaxLevelStore=debug

--- a/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
+++ b/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
@@ -1,5 +1,8 @@
 [Journal]
-Storage=persistent
+Storage=volatile
 ForwardToSyslog=no
-SyncIntervalSec=1s
+SyncIntervalSec=10m
+RuntimeMaxUse=64M
+RateLimitIntervalSec=30s
+RateLimitBurst=2500
 MaxLevelStore=debug


### PR DESCRIPTION
# Overview

While part of the problem is on the Toradex end with the eMMC, there are some things we can do on our end, especially around logging. Right now, we write all logs to flash immediately and force-flush every second, which reduces the memory footprint of the logs. However, it also means we tear through the eMMC lifetime quickly. So let's reduce how often we write to flash when we sync journal logs and generally read/write to flash to reduce wear and tear.

Closes: [EXEC-2648](https://opentrons.atlassian.net/browse/EXEC-2648)

# Changelog

- Change the `SyncIntervalSec` in journal config from 1s to 30s to decrease emmc write rate by ~70%
- Added `commit=10` from 5 (default) to fstab to reduce filesystem journal writes
- Added `noatime` and `nodiratime` to fstab to eliminate unnecessary metadata reads/writes

# Testing and results

Created automated test scripts to systematically measure the **average write rate (MB/min)** and **RAM usage** across different configurations, with 5 minutes per config change.

### 1. SyncIntervalSec Test 

Here are the test results from changing the journal config `SyncIntervalSec=(1s 5s 10s 30s 1m)`
```
Interval   | Avg MB/min | Peak MB/2s | Avg RAM Used %
-------------------------------------------------------------
1s         |      11.11 |       1.37 |         58.4
5s         |       4.95 |       0.72 |         58.5
10s        |       4.19 |       0.57 |         58.5
30s        |       3.06 |       0.84 |         58.4
1m         |       2.75 |       0.63 |         58.5
```

### 2. Commit Test

Here are the test results from changing the fstab options `commit=(1s 5s 10s 30s 60s)`
```
commit=     | Avg MB/min | Peak MB/2s | Avg RAM Used %
--------------------------------------------------
1s         |      11.46 |       0.76 |         58.6
5s         |      10.33 |       0.68 |         58.7
10s        |      10.24 |       0.65 |         58.7
30s        |      10.91 |       0.91 |         58.8
60s        |      10.05 |       0.79 |         58.6
```

### 3. Combined 

Here are the test results from setting `SyncIntervalSec=10s` and changing the fstab `commit=(1s 5s 10s 30s 60s)`
```
commit=     | Avg MB/min | Peak MB/2s | Avg RAM Used %
--------------------------------------------------
1s         |       5.62 |       1.02 |         58.7
5s         |       4.19 |       1.91 |         58.6
10s        |       3.65 |       0.66 |         58.7
30s        |       3.29 |       0.67 |         58.7
60s        |       2.46 |       0.79 |         58.8
```

**Finding:** `SyncIntervalSec=30s` provides the best balance (~70% reduction in writes).
**Finding:** `commit=10s` is a good balance between frequent writes and not losing data on power loss. 
NOTE: We can probably increase this even further; we need to look into [Write-Ahead Logging](https://sqlite.org/wal.html) mode for SQLite to bypass the commit timeout.


# Reviewers


[EXEC-2648]: https://opentrons.atlassian.net/browse/EXEC-2648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ