### PR TITLE
layers/meta-opentrons: Isolate temporary directories and clean them up when services exit

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
@@ -12,6 +12,8 @@ Environment=PYTHONPATH=/opt/opentrons-auth-server
 Environment=OT_AUTH_SERVER_persistence_directory=/var/lib/opentrons-auth-server
 Restart=on-failure
 TimeoutStartSec=3min
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
@@ -19,6 +19,8 @@ Environment=JUPYTER_CONFIG_DIR=%S/jupyter/config
 Environment=JUPYTER_DATA_DIR=%S/jupyter/data
 Environment=JUPYTER_NOTEBOOK_DIR=%S/jupyter/notebooks
 Environment=IPYTHONDIR=%S/ipython
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-key-server/files/opentrons-key-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-key-server/files/opentrons-key-server.service
@@ -21,6 +21,8 @@ Environment=OT_KEY_SERVER_tls_directory=%S/opentrons-key-server/tls
 Environment=OT_KEY_SERVER_tls_server_integration=systemd-nginx
 Restart=on-failure
 TimeoutStartSec=3min
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-live-stream/files/opentrons-live-stream.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-live-stream/files/opentrons-live-stream.service
@@ -28,5 +28,8 @@ ExecStart=/bin/sh -c 'ffmpeg \
 Restart=on-failure
 RestartSec=3
 
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-pyro-nameserver/files/opentrons-pyro-nameserver.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-pyro-nameserver/files/opentrons-pyro-nameserver.service
@@ -9,5 +9,8 @@ ExecStart=/bin/pyro5-ns
 Restart=on-failure
 RestartSec=3
 
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.service
@@ -21,6 +21,8 @@ ExitType=cgroup
 NotifyAccess=all
 Restart=always
 KillSignal=SIGKILL
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
@@ -20,5 +20,8 @@ Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.10/site-pack
 Restart=on-failure
 TimeoutStartSec=10min
 
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
+
 [Install]
 WantedBy=opentrons-robot-server.service

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -26,6 +26,8 @@ Environment=OT_ROBOT_SERVER_maximum_unused_protocols=20
 Environment=OT_ROBOT_SERVER_maximum_quick_transfer_protocols=20
 Restart=on-failure
 TimeoutStartSec=10min
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-system-server/files/opentrons-system-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-system-server/files/opentrons-system-server.service
@@ -15,6 +15,8 @@ Environment=OT_SYSTEM_SERVER_auth_server_uds=/run/opentrons-auth-server.sock
 Environment=OT_SYSTEM_SERVER_persistence_directory=/var/lib/opentrons-system-server
 Restart=on-failure
 TimeoutStartSec=3min
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/files/opentrons-update-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/files/opentrons-update-server.service
@@ -12,6 +12,8 @@ ExecStart=python3 -m otupdate.openembedded -p 34000
 Environment=PYTHONPATH=/opt/opentrons-update-server:/usr/lib/python3.10/site-packages
 Restart=on-failure
 TimeoutStartSec=3min
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/layers/meta-opentrons/recipes-robot/opentrons-usb-bridge/files/opentrons-usb-bridge.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-usb-bridge/files/opentrons-usb-bridge.service
@@ -10,6 +10,8 @@ StateDirectory=opentrons-usb-bridge
 Environment=PYTHONPATH=/opt/ot3usb:/usr/lib/python3.10/site-packages
 Restart=on-failure
 TimeoutStartSec=3min
+# We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Overview

This closes https://opentrons.atlassian.net/browse/EXEC-2673 and goes towards https://opentrons.atlassian.net/browse/EXEC-2672.

# Details

We currently have this funny failure mode:

1. A service starts.
2. The service consumes a bunch of memory.
3. The service writes a bunch of crap to `/tmp`, which consumes even more memory. (Our `/tmp` is pure RAM, a `tmpfs` mount, with no spillover to flash.)
4. The service gets killed because it's using too much memory. The _process's_ memory is released. **But all of the crap that it added to `/tmp` will be left behind, still consuming memory.**
5. systemd restarts the service. Go back to step 1.

Every iteration accumulates more crap in `/tmp`, consuming more memory. After a couple iterations, the system will be totally unresponsive, including basic interaction over SSH.

To fix that, this PR enables [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=) on all long-running Opentrons services. The main use of `PrivateTmp` is that it isolates services from each other, but for this fix, we're taking advantage of a side benefit: if a service fails, systemd can clean up its temp files immediately.

This will not fix the underlying resource exhaustion, but I'm hoping it it will keep the system more responsive and debuggable. The service will still get caught in a startup loop, but its memory usage should now reset to zero after each iteration.

# Test plan

* [x] Try the reproduction steps in EXEC-2672 and see if anything's improved.

# Review requests

I'm not aware of any place where we're deliberately using `/tmp` to share files across services, but double-check me.

# Risk analysis

Medium. This will isolate the services' `/tmp` directories from each other. If we were relying on `/tmp` for inter-service communication, then that will break with this PR. For example, if `opentrons-robot-app` is ever doing something like "hey `robot-server`, go import this file that I've placed in `/tmp/opentrons-robot-app`."