### PR TITLE
fix(ci): add logic for s3 asset upload target

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -319,6 +319,31 @@ jobs:
           role-to-assume: ${{ matrix.build_env == 'stage-dev' && vars.ROBOT_STACK_AWS_OIDC_ROLE_ARN_DEV || vars.ROBOT_STACK_AWS_OIDC_ROLE_ARN_PROD }}
           aws-region: us-east-2
           role-duration-seconds: 43200
+      - name: Set artifact bucket for build variant
+        shell: bash
+        run: |
+          variant="${{ needs.decide-refs.outputs.variant }}"
+          infra_stage="${{ matrix.build_env }}"
+          case "${variant}:${infra_stage}" in
+            internal-release:stage-prod)
+              bucket="arn:aws:s3:::ot3-development.builds.opentrons.com"
+              ;;
+            internal-release:stage-dev)
+              bucket="arn:aws:s3:::dev.ot3-development.builds.opentrons.com"
+              ;;
+            release:stage-prod)
+              bucket="arn:aws:s3:::builds.opentrons.com"
+              ;;
+            release:stage-dev)
+              bucket="arn:aws:s3:::dev.builds.opentrons.com"
+              ;;
+            *)
+              echo "No artifact bucket mapping for variant=${variant} infra_stage=${infra_stage}" >&2
+              exit 1
+              ;;
+          esac
+          echo "S3_ARTIFACT_ARN=${bucket}" >> "$GITHUB_ENV"
+          echo "Uploading artifacts to ${bucket/arn:aws:s3:::/}"
       - name: Apply CI runner customizations
         run: |
           # Ephemeral runners may not permit writing /etc/sysctl*; apply runtime settings only.


### PR DESCRIPTION
## Overview

Ephemeral GitHub Actions runners always set `S3_ARTIFACT_ARN` to the internal artifact bucket (`ot3-development.builds.opentrons.com`). Before ephemeral runners, the workflow selected runners by variant label (`release` vs `internal-release`), and each runner pool had the correct bucket configured in infra.

After the ephemeral runner migration ([#270](https://github.com/Opentrons/oe-core/pull/270)), variant is still resolved correctly by `build-refs`, but artifact uploads rely on the runner-provided `S3_ARTIFACT_ARN`, which is always the internal bucket. This caused external/release builds to upload to the wrong place, for example [v9.1.0-alpha.0](https://github.com/Opentrons/oe-core/actions/runs/26243759221/job/77238371998) uploading to `ot3-development.builds.opentrons.com` instead of `builds.opentrons.com`.

This PR adds an explicit workflow step in `.github/workflows/build-ot3-actions.yml` that sets `S3_ARTIFACT_ARN` from build variant and infra stage before any artifact upload steps run.


## Changelog

- **Fix:** Flex image CI now selects the S3 artifact bucket from build variant (`internal-release` vs `release`) and infra stage, instead of relying on the ephemeral runner's hardcoded internal bucket.
- **Developer note:** Previously mis-uploaded release artifacts (for example v9.1.0-alpha.0) are not moved automatically; re-run the release build or copy artifacts manually if external consumers need them.

## Review requests

- Confirm the four variant/stage → bucket mappings match current infra and are complete for all workflow dispatch combinations.
- Sanity-check that overriding `S3_ARTIFACT_ARN` via `GITHUB_ENV` is sufficient for all downstream steps (`Handle Release`, `Upload results to S3`, Slack/console URL outputs).