### PR TITLE
mergeback chore_release-9.1.0 to main

### DIFF
--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -319,6 +319,31 @@ jobs:
           role-to-assume: ${{ matrix.build_env == 'stage-dev' && vars.ROBOT_STACK_AWS_OIDC_ROLE_ARN_DEV || vars.ROBOT_STACK_AWS_OIDC_ROLE_ARN_PROD }}
           aws-region: us-east-2
           role-duration-seconds: 43200
+      - name: Set artifact bucket for build variant
+        shell: bash
+        run: |
+          variant="${{ needs.decide-refs.outputs.variant }}"
+          infra_stage="${{ matrix.build_env }}"
+          case "${variant}:${infra_stage}" in
+            internal-release:stage-prod)
+              bucket="arn:aws:s3:::ot3-development.builds.opentrons.com"
+              ;;
+            internal-release:stage-dev)
+              bucket="arn:aws:s3:::dev.ot3-development.builds.opentrons.com"
+              ;;
+            release:stage-prod)
+              bucket="arn:aws:s3:::builds.opentrons.com"
+              ;;
+            release:stage-dev)
+              bucket="arn:aws:s3:::dev.builds.opentrons.com"
+              ;;
+            *)
+              echo "No artifact bucket mapping for variant=${variant} infra_stage=${infra_stage}" >&2
+              exit 1
+              ;;
+          esac
+          echo "S3_ARTIFACT_ARN=${bucket}" >> "$GITHUB_ENV"
+          echo "Uploading artifacts to ${bucket/arn:aws:s3:::/}"
       - name: Apply CI runner customizations
         run: |
           # Ephemeral runners may not permit writing /etc/sysctl*; apply runtime settings only.

--- a/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
+++ b/layers/meta-opentrons/recipes-core/base-files/files/custom-fstab
@@ -8,11 +8,11 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 #/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
 
 # opentrons custom mount points
-/dev/mmcblk0p4           /userfs               auto       rw,x-systemd.growfs   0  2
-/userfs/home             /home                 none       defaults,bind         0  0
-/userfs/data             /data                 none       defaults,bind         0  0
-/userfs/media            /media                none       defaults,bind         0  0
-/userfs/var              /var                  none       defaults,bind         0  0
-/userfs/var/mnt          /mnt                  none       defaults,bind         0  0
-/userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail  0  0
-/userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail  0  0
+/dev/mmcblk0p4           /userfs               auto       noatime,nodiratime,commit=10,rw,x-systemd.growfs   0  2
+/userfs/home             /home                 none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/data             /data                 none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/media            /media                none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/var              /var                  none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/var/mnt          /mnt                  none       defaults,bind,noatime,nodiratime,commit=10         0  0
+/userfs/etc/hostname     /etc/hostname         none       defaults,bind,nofail,noatime,nodiratime,commit=10  0  0
+/userfs/etc/machine-info /etc/machine-info     none       defaults,bind,nofail,noatime,nodiratime,commit=10  0  0

--- a/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
+++ b/layers/meta-opentrons/recipes-robot/systemd/systemd-conf/opentrons-journald.conf
@@ -1,5 +1,5 @@
 [Journal]
 Storage=persistent
 ForwardToSyslog=no
-SyncIntervalSec=1s
+SyncIntervalSec=30s
 MaxLevelStore=debug


### PR DESCRIPTION
Merge release isolation branch back to main after 9.1.0 alpha.

Includes fix(ci): add logic for s3 asset upload target (#314) so external
Flex robot builds upload to builds.opentrons.com instead of ot3-development.

Once approved I will
`git push --set-upstream origin mergeback-chore_release-9.1.0:main`