### PR TITLE
fix(ci): require matching tags across repos in build-refs

### DIFF
--- a/.github/actions/build-refs/README.md
+++ b/.github/actions/build-refs/README.md
@@ -5,14 +5,13 @@ This github action is used to determine which git references of the repos that g
 - When a build is started, identify the "authoritative ref", which shall be the first of the following repos in order that is in `S: opentrons, oe-core`. The authoritative ref is `A`.
   - For each repo in `S`, use the specified source revision
   - For each repo `Fi` in `F`
-    - if `A` is the main branch of its repo (i.e. `edge` for monorepo, `main` for oe-core), use the main branch of `Fi`
-    - if `A` is a branch that is not the main branch of its repo
+    - if `A` is the default branch of its repo (i.e. `edge` for monorepo, `main` for oe-core), use the default branch of `Fi`
+    - if `A` is a branch that is not the default branch of its repo
       - and a branch of the same name exists in `Fi`, use that matching branch
-      - and a branch of the same name does not exist in `Fi`, use the main branch of `Fi`
+      - and a branch of the same name does not exist in `Fi`, use the default branch of `Fi`
     - if `A` is a tag
-      - and a tag of the same name exists in `Fi`, use that tag
-      - and a tag of the same name does not exist in `Fi`, but other tags exist in `Fi`, use the latest tag in `Fi`
-      - and a tag of the same name does not exist in `Fi` and there are no tags in `Fi`, use `Fi`'s main branch
+      - for each repo `Fi` whose ref is not specified, use that tag on `Fi`
+      - fail the build if that tag does not exist on `Fi`
 
 ## Developing
 

--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -29,7 +29,7 @@ const AUTHORITATIVE_REF_TEST_SPECS: Array<
     ['refs/heads/edge', true],
   ],
   [
-    'identifies if monorepo preferred but on non-main branch',
+    'identifies if monorepo preferred but on non-default branch',
     new Map([
       ['oe-core', 'refs/heads/main'],
       ['monorepo', 'refs/heads/some-test-branch'],
@@ -37,7 +37,7 @@ const AUTHORITATIVE_REF_TEST_SPECS: Array<
     ['refs/heads/some-test-branch', false],
   ],
   [
-    'identifies if oe-core preferred but on non-main branch',
+    'identifies if oe-core preferred but on non-default branch',
     new Map([
       ['oe-core', 'refs/heads/some-test-branch'],
       ['monorepo', null],
@@ -45,7 +45,7 @@ const AUTHORITATIVE_REF_TEST_SPECS: Array<
     ['refs/heads/some-test-branch', false],
   ],
   [
-    'falls back to main branches if nothing is specified',
+    'falls back to default branches if nothing is specified',
     new Map([
       ['oe-core', null],
       ['monorepo', null],
@@ -66,34 +66,48 @@ const REFS_TO_ATTEMPT_TEST_SPECS: Array<
   [string, [Ref, boolean, Branch], Ref[]]
 > = [
   [
-    'with non-main branches should prioritize the request and then use main',
-    ['refs/heads/someBranch', false, 'refs/heads/someMain'],
-    ['refs/heads/someBranch', 'refs/heads/someMain'],
+    'with non-default branches should prioritize the request and then use default branch',
+    ['refs/heads/someBranch', false, 'refs/heads/someDefaultBranch'],
+    ['refs/heads/someBranch', 'refs/heads/someDefaultBranch'],
   ],
   [
-    'with main branches should just use main',
-    ['refs/heads/someOtherMain', true, 'refs/heads/someMain'],
-    ['refs/heads/someMain'],
+    'with default branches should just use default branch',
+    ['refs/heads/someOtherDefaultBranch', true, 'refs/heads/someDefaultBranch'],
+    ['refs/heads/someDefaultBranch'],
   ],
   [
-    'with tags should prioritize match tag, then latest',
-    ['refs/tags/someTag', false, 'refs/heads/someMain'],
-    ['refs/tags/someTag', ':latest:', 'refs/heads/someMain'],
+    'with tags should require the matching tag only',
+    ['refs/tags/someTag', false, 'refs/heads/someDefaultBranch'],
+    ['refs/tags/someTag'],
+  ],
+  [
+    'with coordinated ot3 tags should require the matching tag only',
+    ['refs/tags/ot3@8.5.0-alpha.0', false, 'refs/heads/someDefaultBranch'],
+    ['refs/tags/ot3@8.5.0-alpha.0'],
+  ],
+  [
+    'with external firmware tags should require the matching tag only',
+    ['refs/tags/v10.0.0-beta.1', false, 'refs/heads/someDefaultBranch'],
+    ['refs/tags/v10.0.0-beta.1'],
   ],
 ]
 
 REFS_TO_ATTEMPT_TEST_SPECS.forEach(
   ([
     testNameFragment,
-    [testRequesterRef, testRequesterIsMain, testRequestedMain],
+    [
+      testRequesterRef,
+      testRequesterIsDefaultBranch,
+      testRequestedDefaultBranch,
+    ],
     testResults,
   ]) => {
     test(`refsToAttempt ${testNameFragment}`, () => {
       expect(
         action.refsToAttempt(
           testRequesterRef,
-          testRequesterIsMain,
-          testRequestedMain
+          testRequesterIsDefaultBranch,
+          testRequestedDefaultBranch
         )
       ).toStrictEqual(testResults)
     })
@@ -105,21 +119,25 @@ const REFS_TO_ATTEMPT_FAILURE_TEST_SPECS: Array<
 > = [
   [
     'when called with a short refname throws',
-    ['shortBranchName', true, 'refs/heads/someMain'],
+    ['shortBranchName', true, 'refs/heads/someDefaultBranch'],
   ],
 ]
 
 REFS_TO_ATTEMPT_FAILURE_TEST_SPECS.forEach(
   ([
     testNameFragment,
-    [testRequesterRef, testRequesterIsMain, testRequestedMain],
+    [
+      testRequesterRef,
+      testRequesterIsDefaultBranch,
+      testRequestedDefaultBranch,
+    ],
   ]) => {
     test(`refsToAttempt ${testNameFragment}`, () => {
       expect(() => {
         action.refsToAttempt(
           testRequesterRef,
-          testRequesterIsMain,
-          testRequestedMain
+          testRequesterIsDefaultBranch,
+          testRequestedDefaultBranch
         )
       }).toThrow()
     })
@@ -268,6 +286,23 @@ LATEST_TAG_TEST_SPECS.forEach(
   ([testNameFragment, testTagRefs, testExpectedResult]) => {
     test(`latestTag ${testNameFragment}`, () => {
       expect(action.latestTag(testTagRefs)).toStrictEqual(testExpectedResult)
+    })
+  }
+)
+
+const COORDINATED_RELEASE_TAG_SPECS: Array<[string, Ref, boolean]> = [
+  ['ot3 internal alpha', 'refs/tags/ot3@8.5.0-alpha.0', true],
+  ['ot3 internal beta', 'refs/tags/ot3@8.5.0-beta.1', true],
+  ['external beta', 'refs/tags/v10.0.0-beta.1', true],
+  ['external alpha', 'refs/tags/v10.0.0-alpha.0', true],
+  ['edge branch', 'refs/heads/edge', false],
+  ['legacy internal@ tag alone', 'refs/tags/internal@8.5.0', false],
+]
+
+COORDINATED_RELEASE_TAG_SPECS.forEach(
+  ([testNameFragment, testRef, expected]) => {
+    test(`isCoordinatedReleaseTag ${testNameFragment}`, () => {
+      expect(action.isCoordinatedReleaseTag(testRef)).toStrictEqual(expected)
     })
   }
 )

--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -293,8 +293,10 @@ LATEST_TAG_TEST_SPECS.forEach(
 const COORDINATED_RELEASE_TAG_SPECS: Array<[string, Ref, boolean]> = [
   ['ot3 internal alpha', 'refs/tags/ot3@8.5.0-alpha.0', true],
   ['ot3 internal beta', 'refs/tags/ot3@8.5.0-beta.1', true],
+  ['ot3 internal stable', 'refs/tags/ot3@8.5.0', true],
   ['external beta', 'refs/tags/v10.0.0-beta.1', true],
   ['external alpha', 'refs/tags/v10.0.0-alpha.0', true],
+  ['external stable', 'refs/tags/v10.0.0', true],
   ['edge branch', 'refs/heads/edge', false],
   ['legacy internal@ tag alone', 'refs/tags/internal@8.5.0', false],
 ]

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -20,14 +20,13 @@ export type Ref = Branch | Tag
 
 export type InputRefs = Map<Repo, Ref | null>
 
-export type AttemptableTag = Tag | ':latest:'
-export type AttemptableRef = AttemptableTag | Branch
+export type AttemptableRef = Tag | Branch
 
 export type AttemptableRefs = Map<Repo, AttemptableRef[]>
 
 export type OutputRefs = Map<Repo, Ref>
 
-function mainRefFor(input: Repo): Branch {
+function defaultBranchRefFor(input: Repo): Branch {
   return {
     monorepo: 'refs/heads/edge',
     'oe-core': 'refs/heads/main',
@@ -58,19 +57,6 @@ export function resolveBuildVariant(ref: Ref): Variant {
     }
   }
   return 'internal-release'
-}
-
-function latestTagPrefixFor(repo: Repo, variant: Variant): string[] {
-  if (variant === 'release') {
-    return ['refs/tags/v']
-  }
-  if (variant === 'internal-release') {
-    if (repo === 'monorepo') return ['refs/tags/internal@', 'refs/tags/ot3@v']
-    if (repo === 'oe-core') return ['refs/tags/internal@']
-    if (repo === 'ot3-firmware') return ['refs/tags/internal@']
-    throw new Error(`Unknown repo ${repo}`)
-  }
-  throw new Error(`Unknown variant ${variant}`)
 }
 
 export function latestTag(tagRefs: GitHubApiTag[]): Tag | null {
@@ -153,8 +139,8 @@ function restDetailsFor(input: Repo): { owner: string; repo: string } {
   }[input]
 }
 
-function refIsMain(input: Ref, repo: Repo): boolean {
-  return mainRefFor(repo) === input
+function refIsDefaultBranch(input: Ref, repo: Repo): boolean {
+  return defaultBranchRefFor(repo) === input
 }
 
 export function authoritativeRef(inputs: InputRefs): [Ref, boolean] {
@@ -163,7 +149,7 @@ export function authoritativeRef(inputs: InputRefs): [Ref, boolean] {
       .map((repoName): [Ref, boolean] | null => {
         const inputRefForRepo = inputs.get(repoName)
         return inputRefForRepo
-          ? [inputRefForRepo, refIsMain(inputRefForRepo, repoName)]
+          ? [inputRefForRepo, refIsDefaultBranch(inputRefForRepo, repoName)]
           : null
       })
       .find(el => el !== null) ?? ['refs/heads/edge', true]
@@ -191,74 +177,55 @@ function visitRefsByType<T>(
 
 function branchesToAttempt(
   requesterBranch: Branch,
-  requesterIsMain: boolean,
-  requestedMain: Branch
+  requesterIsDefaultBranch: boolean,
+  requestedDefaultBranch: Branch
 ): Ref[] {
-  // if this is a main-branch build, use our main branch
-  if (requesterIsMain) {
-    return [requestedMain]
+  // if this is a default-branch build, use our default branch
+  if (requesterIsDefaultBranch) {
+    return [requestedDefaultBranch]
   }
-  // otherwise, use a matching branchname and then our main branch
-  return [requesterBranch, requestedMain]
+  // otherwise, use a matching branchname and then our default branch
+  return [requesterBranch, requestedDefaultBranch]
 }
 
-function tagsToAttempt(
-  requesterTag: Tag,
-  requestedMain: Branch
-): AttemptableTag[] {
-  return [requesterTag, ':latest:', requestedMain]
+/** Return whether a ref is a coordinated Flex release tag (ot3@* or v*). */
+export function isCoordinatedReleaseTag(ref: Ref): boolean {
+  if (!ref.startsWith('refs/tags/')) {
+    return false
+  }
+  const tagName = ref.slice('refs/tags/'.length)
+  return tagName.startsWith('ot3@') || tagName.startsWith('v')
+}
+
+function tagsToAttempt(requesterTag: Tag): Ref[] {
+  // Tag builds require the same tag on every repo; no default-branch fallback.
+  return [requesterTag]
 }
 
 export function refsToAttempt(
   requesterRef: Ref,
-  requesterIsMain: boolean,
-  requestedMain: Branch
+  requesterIsDefaultBranch: boolean,
+  requestedDefaultBranch: Branch
 ): Ref[] {
   ///Based on the refs from whatever was specified, return an ordered list of refs to
   // try.
   return visitRefsByType(
     requesterRef,
     requesterBranch =>
-      branchesToAttempt(requesterBranch, requesterIsMain, requestedMain),
-    requesterTag => tagsToAttempt(requesterTag, requestedMain)
+      branchesToAttempt(
+        requesterBranch,
+        requesterIsDefaultBranch,
+        requestedDefaultBranch
+      ),
+    requesterTag => tagsToAttempt(requesterTag)
   )
 }
 
-async function resolveRefs(
-  toAttempt: AttemptableRefs,
-  variant: Variant
-): Promise<OutputRefs> {
+async function resolveRefs(toAttempt: AttemptableRefs): Promise<OutputRefs> {
   const token = core.getInput('token')
   let resolved = new Map()
   for (const [repo, refList] of toAttempt) {
     const octokit = getOctokit(token)
-
-    const fetchTags = async (repoName: Repo): Promise<Ref | null> => {
-      core.info(`finding latest tag for ${repoName}`)
-      return Promise.all(
-        latestTagPrefixFor(repoName, variant).map(prefix =>
-          octokit.rest.git
-            .listMatchingRefs({
-              ...restDetailsFor(repoName),
-              ref: restAPICompliantRef(prefix),
-            })
-            .then((response: any) => {
-              if (response.status != 200) {
-                throw new Error(
-                  `Bad response from github api for ${repoName} get tags: ${response.status}`
-                )
-              }
-              const latest = latestTag(response.data)
-              core.debug(
-                `latest tag for ${repoName} variant ${variant} is ${latest}`
-              )
-              return latest
-            })
-        )
-      ).then(results =>
-        results.reduce((prev: any, current: any) => prev ?? current, null)
-      )
-    }
 
     // this is a big function to be inline and untestable, but tookit doesn't export
     // the type for the octokit object above so what are you gonna do
@@ -267,16 +234,11 @@ async function resolveRefs(
       ref: AttemptableRef
     ): Promise<Ref | null> => {
       core.info(`looking for ${ref} on ${repoName}`)
-      const correctRef = ref === ':latest:' ? await fetchTags(repoName) : ref
-      if (correctRef === null) {
-        core.info(`couldn't find ref ${correctRef} for ${ref} on ${repoName}`)
-        return null
-      }
 
       return octokit.rest.git
         .listMatchingRefs({
           ...restDetailsFor(repoName),
-          ref: restAPICompliantRef(correctRef),
+          ref: restAPICompliantRef(ref),
         })
         .then((value: any) => {
           if (value.status != 200 || !value.data) {
@@ -286,7 +248,7 @@ async function resolveRefs(
           }
           const availableRefs = value.data.map((refObj: any) => refObj.ref)
           core.info(`refs on ${repoName} matching ${ref}: ${availableRefs}`)
-          return availableRefs.includes(correctRef) ? correctRef : null
+          return availableRefs.includes(ref) ? ref : null
         })
     }
 
@@ -320,8 +282,10 @@ async function run() {
   inputs.forEach((ref, repo) => {
     core.debug(`found input for ${repo}: ${ref}`)
   })
-  const [authoritative, isMain] = authoritativeRef(inputs)
-  core.debug(`authoritative ref is ${authoritative} (main: ${isMain})`)
+  const [authoritative, isDefaultBranch] = authoritativeRef(inputs)
+  core.debug(
+    `authoritative ref is ${authoritative} (default branch: ${isDefaultBranch})`
+  )
   const buildType = resolveBuildType(authoritative)
   const buildVariant = resolveBuildVariant(authoritative)
   core.info(`Resolved build type to ${buildType}`)
@@ -333,7 +297,11 @@ async function run() {
         repoName,
         inputRef
           ? [inputRef]
-          : refsToAttempt(authoritative, isMain, mainRefFor(repoName))
+          : refsToAttempt(
+              authoritative,
+              isDefaultBranch,
+              defaultBranchRefFor(repoName)
+            )
       )
     },
     new Map()
@@ -344,11 +312,16 @@ async function run() {
   setOutput('build-type', buildType)
   setOutput('variant', buildVariant)
 
-  const resolved = await resolveRefs(attemptable, buildVariant)
+  const resolved = await resolveRefs(attemptable)
   resolved.forEach((ref, repo) => {
     if (!ref) {
+      const inputRef = inputs.get(repo)
+      const tagHint =
+        authoritative.startsWith('refs/tags/') && inputRef === null
+          ? ` Tag builds require the same tag (${authoritative}) on all repos.`
+          : ''
       throw new Error(
-        `Could not resolve ${repo} input reference ${inputs.get(repo)}`
+        `Could not resolve ${repo} input reference ${inputRef}.${tagHint}`
       )
     }
     core.info(`Resolved ${repo} to ${ref}`)

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -34569,6 +34569,7 @@ var __webpack_exports__ = {};
 __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   authoritativeRef: () => (/* binding */ authoritativeRef),
+/* harmony export */   isCoordinatedReleaseTag: () => (/* binding */ isCoordinatedReleaseTag),
 /* harmony export */   latestTag: () => (/* binding */ latestTag),
 /* harmony export */   refsToAttempt: () => (/* binding */ refsToAttempt),
 /* harmony export */   resolveBuildType: () => (/* binding */ resolveBuildType),
@@ -34597,7 +34598,7 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 const orderedRepos = ['monorepo', 'oe-core', 'ot3-firmware'];
-function mainRefFor(input) {
+function defaultBranchRefFor(input) {
     return {
         monorepo: 'refs/heads/edge',
         'oe-core': 'refs/heads/main',
@@ -34625,21 +34626,6 @@ function resolveBuildVariant(ref) {
         }
     }
     return 'internal-release';
-}
-function latestTagPrefixFor(repo, variant) {
-    if (variant === 'release') {
-        return ['refs/tags/v'];
-    }
-    if (variant === 'internal-release') {
-        if (repo === 'monorepo')
-            return ['refs/tags/internal@', 'refs/tags/ot3@v'];
-        if (repo === 'oe-core')
-            return ['refs/tags/internal@'];
-        if (repo === 'ot3-firmware')
-            return ['refs/tags/internal@'];
-        throw new Error(`Unknown repo ${repo}`);
-    }
-    throw new Error(`Unknown variant ${variant}`);
 }
 function latestTag(tagRefs) {
     if (tagRefs.length === 0)
@@ -34716,8 +34702,8 @@ function restDetailsFor(input) {
         'ot3-firmware': { owner: 'Opentrons', repo: 'ot3-firmware' },
     }[input];
 }
-function refIsMain(input, repo) {
-    return mainRefFor(repo) === input;
+function refIsDefaultBranch(input, repo) {
+    return defaultBranchRefFor(repo) === input;
 }
 function authoritativeRef(inputs) {
     var _a;
@@ -34725,7 +34711,7 @@ function authoritativeRef(inputs) {
         .map((repoName) => {
         const inputRefForRepo = inputs.get(repoName);
         return inputRefForRepo
-            ? [inputRefForRepo, refIsMain(inputRefForRepo, repoName)]
+            ? [inputRefForRepo, refIsDefaultBranch(inputRefForRepo, repoName)]
             : null;
     })
         .find(el => el !== null)) !== null && _a !== void 0 ? _a : ['refs/heads/edge', true]);
@@ -34743,59 +34729,50 @@ function visitRefsByType(ref, ifBranch, ifTag) {
         return ifTag(ref);
     throw new Error(`Ref ${ref} can't be matched to branch or tag, is it a shortref?`);
 }
-function branchesToAttempt(requesterBranch, requesterIsMain, requestedMain) {
-    // if this is a main-branch build, use our main branch
-    if (requesterIsMain) {
-        return [requestedMain];
+function branchesToAttempt(requesterBranch, requesterIsDefaultBranch, requestedDefaultBranch) {
+    // if this is a default-branch build, use our default branch
+    if (requesterIsDefaultBranch) {
+        return [requestedDefaultBranch];
     }
-    // otherwise, use a matching branchname and then our main branch
-    return [requesterBranch, requestedMain];
+    // otherwise, use a matching branchname and then our default branch
+    return [requesterBranch, requestedDefaultBranch];
 }
-function tagsToAttempt(requesterTag, requestedMain) {
-    return [requesterTag, ':latest:', requestedMain];
+/** Return whether a ref is a coordinated Flex release tag (ot3@* or v*). */
+function isCoordinatedReleaseTag(ref) {
+    if (!ref.startsWith('refs/tags/')) {
+        return false;
+    }
+    const tagName = ref.slice('refs/tags/'.length);
+    return tagName.startsWith('ot3@') || tagName.startsWith('v');
 }
-function refsToAttempt(requesterRef, requesterIsMain, requestedMain) {
+function tagsToAttempt(requesterTag) {
+    // Tag builds require the same tag on every repo; no default-branch fallback.
+    return [requesterTag];
+}
+function refsToAttempt(requesterRef, requesterIsDefaultBranch, requestedDefaultBranch) {
     ///Based on the refs from whatever was specified, return an ordered list of refs to
     // try.
-    return visitRefsByType(requesterRef, requesterBranch => branchesToAttempt(requesterBranch, requesterIsMain, requestedMain), requesterTag => tagsToAttempt(requesterTag, requestedMain));
+    return visitRefsByType(requesterRef, requesterBranch => branchesToAttempt(requesterBranch, requesterIsDefaultBranch, requestedDefaultBranch), requesterTag => tagsToAttempt(requesterTag));
 }
-function resolveRefs(toAttempt, variant) {
+function resolveRefs(toAttempt) {
     return __awaiter(this, void 0, void 0, function* () {
         const token = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput('token');
         let resolved = new Map();
         for (const [repo, refList] of toAttempt) {
             const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_0__.getOctokit)(token);
-            const fetchTags = (repoName) => __awaiter(this, void 0, void 0, function* () {
-                _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`finding latest tag for ${repoName}`);
-                return Promise.all(latestTagPrefixFor(repoName, variant).map(prefix => octokit.rest.git
-                    .listMatchingRefs(Object.assign(Object.assign({}, restDetailsFor(repoName)), { ref: restAPICompliantRef(prefix) }))
-                    .then((response) => {
-                    if (response.status != 200) {
-                        throw new Error(`Bad response from github api for ${repoName} get tags: ${response.status}`);
-                    }
-                    const latest = latestTag(response.data);
-                    _actions_core__WEBPACK_IMPORTED_MODULE_1__.debug(`latest tag for ${repoName} variant ${variant} is ${latest}`);
-                    return latest;
-                }))).then(results => results.reduce((prev, current) => prev !== null && prev !== void 0 ? prev : current, null));
-            });
             // this is a big function to be inline and untestable, but tookit doesn't export
             // the type for the octokit object above so what are you gonna do
             const refResolves = (repoName, ref) => __awaiter(this, void 0, void 0, function* () {
                 _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`looking for ${ref} on ${repoName}`);
-                const correctRef = ref === ':latest:' ? yield fetchTags(repoName) : ref;
-                if (correctRef === null) {
-                    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`couldn't find ref ${correctRef} for ${ref} on ${repoName}`);
-                    return null;
-                }
                 return octokit.rest.git
-                    .listMatchingRefs(Object.assign(Object.assign({}, restDetailsFor(repoName)), { ref: restAPICompliantRef(correctRef) }))
+                    .listMatchingRefs(Object.assign(Object.assign({}, restDetailsFor(repoName)), { ref: restAPICompliantRef(ref) }))
                     .then((value) => {
                     if (value.status != 200 || !value.data) {
                         throw new Error(`Bad response from github api for ${repoName} get matching refs: ${value.status}`);
                     }
                     const availableRefs = value.data.map((refObj) => refObj.ref);
                     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`refs on ${repoName} matching ${ref}: ${availableRefs}`);
-                    return availableRefs.includes(correctRef) ? correctRef : null;
+                    return availableRefs.includes(ref) ? ref : null;
                 });
             });
             resolved.set(repo, yield Promise.all(refList.map(ref => refResolves(repo, ref))).then(presentRefs => presentRefs.find(maybeRef => maybeRef !== null) || null));
@@ -34821,8 +34798,8 @@ function run() {
         inputs.forEach((ref, repo) => {
             _actions_core__WEBPACK_IMPORTED_MODULE_1__.debug(`found input for ${repo}: ${ref}`);
         });
-        const [authoritative, isMain] = authoritativeRef(inputs);
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.debug(`authoritative ref is ${authoritative} (main: ${isMain})`);
+        const [authoritative, isDefaultBranch] = authoritativeRef(inputs);
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.debug(`authoritative ref is ${authoritative} (default branch: ${isDefaultBranch})`);
         const buildType = resolveBuildType(authoritative);
         const buildVariant = resolveBuildVariant(authoritative);
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Resolved build type to ${buildType}`);
@@ -34830,17 +34807,21 @@ function run() {
         const attemptable = Array.from(inputs.entries()).reduce((prev, [repoName, inputRef]) => {
             return prev.set(repoName, inputRef
                 ? [inputRef]
-                : refsToAttempt(authoritative, isMain, mainRefFor(repoName)));
+                : refsToAttempt(authoritative, isDefaultBranch, defaultBranchRefFor(repoName)));
         }, new Map());
         attemptable.forEach((refs, repo) => {
             _actions_core__WEBPACK_IMPORTED_MODULE_1__.debug(`found attemptable refs for ${repo}: ${refs.join(', ')}`);
         });
         setOutput('build-type', buildType);
         setOutput('variant', buildVariant);
-        const resolved = yield resolveRefs(attemptable, buildVariant);
+        const resolved = yield resolveRefs(attemptable);
         resolved.forEach((ref, repo) => {
             if (!ref) {
-                throw new Error(`Could not resolve ${repo} input reference ${inputs.get(repo)}`);
+                const inputRef = inputs.get(repo);
+                const tagHint = authoritative.startsWith('refs/tags/') && inputRef === null
+                    ? ` Tag builds require the same tag (${authoritative}) on all repos.`
+                    : '';
+                throw new Error(`Could not resolve ${repo} input reference ${inputRef}.${tagHint}`);
             }
             _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Resolved ${repo} to ${ref}`);
             setOutput(repo, ref);

--- a/.github/workflows/test-build-refs.yml
+++ b/.github/workflows/test-build-refs.yml
@@ -1,12 +1,10 @@
 name: "Test the build-refs js action"
 
 on:
-  push:
-    branches:
-      - '*'
+  pull_request:
     paths:
       - ".github/workflows/test-build-refs.yml"
-      - ".github/actions/build-refs/**/*"
+      - ".github/actions/build-refs/**"
 
 jobs:
   check-action:


### PR DESCRIPTION
## Overview

Tightens the `build-refs` GitHub Action so tag-based Flex builds require the same tag on `opentrons`, `oe-core`, and `ot3-firmware`. Previously, missing tags could fall back to latest tags or default branches, which could produce inconsistent release builds if some tag were pushed unexpectedly.

Also renames internal "main branch" terminology to "default branch" (`edge` for monorepo, `main` for stack repos) to better reflect actual behavior.

**Acceptance criteria**
- Branch-based development builds behave as before (feature branch matching, then default branch fallback).
- Tag-based builds only resolve the authoritative tag on each unspecified repo.
- Tag builds fail with a clear error when any repo lacks that tag.

**Breaking change:** tag dispatches that relied on `:latest:` or default-branch fallback when a coordinated tag was missing will now fail in `decide-refs` instead of proceeding.

## Test Plan and Hands on Testing

- [x] `cd .github/actions/build-refs && npm test` (38 tests)
- [x] `npm run format-check`
- [x] `npm run build` (rebuilt `dist/index.js`)
- [x] CI: `Test the build-refs js action` workflow on this branch

## Changelog

- **build-refs:** tag builds require the matching tag on all three repos; no latest-tag or default-branch fallback.
- **build-refs:** clearer error when a tag is missing on an inferred repo.
- **build-refs:** rename main-branch flags/helpers to default-branch naming (behavior unchanged for branch builds).

## Review requests

- Confirm tag-build failure is desired for all tag prefixes (not only `ot3@*` / `v*`).
- Confirm removal of `:latest:` resolution is acceptable for release workflows.

## Risk assessment

**Attention level:** medium

- **Blast radius:** `build-ot3-actions.yml` ref resolution for tag dispatches only; branch dev builds unchanged.
- **Mitigation:** unit tests cover branch and tag resolution paths; coordinated tag cases explicitly tested.