### PR TITLE
feat(layers/meta-opentrons): Add smartscan barcode scanner to udev rules

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/95-opentrons-udev.rules
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/95-opentrons-udev.rules
@@ -25,4 +25,7 @@ KERNEL=="video[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="9230", ATTRS{idVend
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ef40", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_vacuummodule%n"
 
 # barcode scanner
+#RTSCAN
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="1d06", ATTRS{idVendor}=="1eab", SYMLINK+="ot_module_barcodescanner%n"
+#SMARTSCANNER
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="3003", ATTRS{idVendor}=="ac90", SYMLINK+="ot_module_barcodescanner%n"


### PR DESCRIPTION
This is the brand of scanner they want to use on the line so this just adds the udev rules, driver is added in a separate monorepo PR 