### PR TITLE
chore: fix update_releases_file

### DIFF
--- a/scripts/update_releases_file.py
+++ b/scripts/update_releases_file.py
@@ -28,16 +28,14 @@ def main(args):
             releases = json.load(fh)
 
     # Update the releases dict with the latest version
-    releases.get("productionV2", {}).update(
-        {
-            f"{version}": {
-                "fullImage": f"{base_url}/ot3-fullimage.tar",
-                "system": f"{base_url}/ot3-system.zip",
-                "version": f"{base_url}/VERSION.json",
-                "releaseNotes": f"{base_url}/release-notes.md",
-            }
-        }
-    )
+    if 'productionV2' not in releases:
+        releases['productionV2'] = {}
+    releases['productionV2'][f'{version}'] = {
+        "fullImage": f"{base_url}/ot3-fullimage.tar",
+        "system": f"{base_url}/ot3-system.zip",
+        "version": f"{base_url}/VERSION.json",
+        "releaseNotes": f"{base_url}/release-notes.md",
+    }
 
     # Save the new releases.json file
     with open(releases_file, "w") as fh:


### PR DESCRIPTION
Tested with current releases and a version from a robot, estalbishes v2 and prints. Must have messed up testing it last time.