### PR TITLE
fix(audit-server): use global numpy for shared-data dependency

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-audit-server/opentrons-audit-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-audit-server/opentrons-audit-server.bb
@@ -21,7 +21,7 @@ SRC_URI:append = " file://opentrons-audit-server.service"
 
 OPENTRONS_APP_BUNDLE_PROJECT_ROOT = "${S}/audit-server"
 OPENTRONS_APP_BUNDLE_DIR = "/opt/opentrons-audit-server"
-OPENTRONS_APP_BUNDLE_USE_GLOBAL = "systemd-python python3-cryptography python3-cffi "
+OPENTRONS_APP_BUNDLE_USE_GLOBAL = "numpy systemd-python python3-cryptography python3-cffi "
 OPENTRONS_APP_BUNDLE_EXTRA_PIP_ENVARGS_LOCAL = "OPENTRONS_PROJECT=${OPENTRONS_PROJECT} ${@get_ot_package_version_override(d)}"
 OPENTRONS_APP_BUNDLE_PACKAGE_SOURCE = "uv"
 
@@ -50,7 +50,7 @@ FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-audit-server.service.d
                        ${systemd_system_unitdir}/nginx.target.wants/opentrons-audit-server.service \
                        "
 
-RDEPENDS:${PN} += " nginx python3-systemd python3-cryptography "
+RDEPENDS:${PN} += " nginx python3-numpy python3-systemd python3-cryptography "
 
 DEPENDS += " cargo-native "
 


### PR DESCRIPTION
## Overview

Fixes the `opentrons-audit-server` BitBake `do_compile` failure seen in [oe-core run #11851](https://github.com/Opentrons/oe-core/actions/runs/28874004753/job/85644379158) when building `opentrons` `edge` on stage-prod.

`audit-server` recently gained an `opentrons-shared-data` dependency ([opentrons#21822](https://github.com/Opentrons/opentrons/pull/21822)), which transitively requires `numpy==1.26.4`. The `opentrons_app_bundle` class installs pip deps with `--no-binary :all:` and `--no-build-isolation`, so pip tries to build numpy from source and fails with `BackendUnavailable: Cannot import 'mesonpy'`.

`robot-server` already handles this by listing `numpy` in `OPENTRONS_APP_BUNDLE_USE_GLOBAL` and depending on `python3-numpy` from Yocto. This PR applies the same pattern to `opentrons-audit-server.bb`.

**Acceptance criteria:** stage-prod Flex image builds that include `opentrons-audit-server` complete `do_compile` without attempting to pip-build numpy.

## Changelog

- Route `numpy` through the Yocto `python3-numpy` package in `opentrons-audit-server` instead of pip-building it from source

## Review requests

- Does mirroring `robot-server`'s `OPENTRONS_APP_BUNDLE_USE_GLOBAL` / `RDEPENDS` pattern look right for audit-server's new `shared-data` dependency?

## Risk assessment

**Attention level:** low

This is a two-line recipe change matching an established pattern. Blast radius is limited to `opentrons-audit-server` packaging on the robot image.