### PR TITLE
fix(app-bundle): install maturin 1.9.6 for rpds-py builds

### DIFF
--- a/layers/meta-opentrons/classes/opentrons_app_bundle.bbclass
+++ b/layers/meta-opentrons/classes/opentrons_app_bundle.bbclass
@@ -191,6 +191,7 @@ do_compile () {
       wheel==0.45.1 \
       expandvars==1.0.0 \
       cython==3.1.1 \
+      maturin==1.9.6 \
       setuptools_rust==1.11.1 \
       typing-extensions==4.15.0 \
       poetry-core==2.2.1 \


### PR DESCRIPTION
## Overview

Fixes the `opentrons-audit-server` `do_compile` failure seen in [oe-core CI run #28880755869](https://github.com/Opentrons/oe-core/actions/runs/28880755869/job/85668315895).

### What is maturin?

[Maturin](https://github.com/PyO3/maturin) is a build tool for Python packages that include Rust code. Many modern Python libraries with native Rust extensions (for example `rpds-py`, `pydantic-core`, and others built with PyO3) declare `maturin` as their PEP 517 build backend. During `pip install`, maturin compiles the Rust sources into a Python importable extension module.

Our app-bundle recipes install Python dependencies with pip using `--no-build-isolation`, so pip reuses build tools already on `PATH` instead of fetching fresh ones per package. BitBake provides `python3-maturin-native` **1.4.0**, which is what pip was picking up.

### Why this failed

`opentrons-audit-server` is currently the only robot image server whose robot dependency export includes `opentrons-shared-data`. That pulls in a newer JSON Schema stack:

`shared-data` → `jsonschema==4.26.0` → `referencing` → **`rpds-py==0.30.0`**

`rpds-py` 0.30.0 requires **`maturin>=1.9`** and uses PEP 639 metadata (`license-files = ["LICENSE"]`) that maturin 1.4.0 cannot parse. Pip therefore fails while generating metadata for `rpds-py`, and audit-server fails to compile.

Other app-bundle servers (auth-server, key-server, robot-server, etc.) do not hit this today because their robot exports do not pull in `rpds-py` 0.30.0. Robot-server still resolves an older `jsonschema==4.17.3` without that dependency chain.

There is no existing per-recipe workaround for this in oe-core. Audit-server already uses `OPENTRONS_APP_BUNDLE_USE_GLOBAL` for native packages like `numpy` (#339), but oe-core only ships `python3-rpds-py` 0.18.0, so we cannot reuse that pattern for `rpds-py` 0.30.0 without a separate recipe bump.

### What this change does

Install **`maturin==1.9.6`** into the pip buildenv in `opentrons_app_bundle.bbclass`, alongside the other build tools we already bootstrap there (`setuptools_rust`, `hatchling`, etc.). Because `${B}/pip-buildenv/bin/` is prepended to `PATH` before pip installs run, pip uses this newer maturin instead of BitBake's 1.4.0 native binary.

This is a shared fix in the app-bundle bbclass rather than an audit-server-only recipe tweak, so any future server that pip-builds modern Rust Python packages gets the same tool version.

Related monorepo fix for the separate robot-app lockfile failure: https://github.com/Opentrons/opentrons/pull/21888

## Changelog

- Install `maturin==1.9.6` in the app-bundle pip buildenv so `rpds-py` and other modern Rust Python packages can build during image builds

## Review requests

- Confirm pinning `maturin==1.9.6` in the pip buildenv is preferable to bumping the BitBake `python3-maturin-native` recipe globally
- Sanity check that prepending the buildenv to `PATH` is sufficient for pip to pick up the newer maturin (same pattern already used for `setuptools_rust`)

## Risk assessment

- **Attention level**: low
- **Trade-offs**: adds one pinned pip package to an existing bootstrap step; does not change runtime packages on the robot
- **Blast radius**: all recipes inheriting `opentrons_app_bundle` (audit-server, auth-server, robot-server, etc.), but only affects packages that pip-build from source with maturin
- **Side effects**: should be neutral for servers that already build successfully; enables builds for newer Rust Python dependencies like `rpds-py` 0.30.0