### PR TITLE
opentrons-audit-server: add key server UDS config

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
@@ -14,6 +14,7 @@ ExecStart=python3 -m audit_server --uds /run/opentrons-audit-server.sock
 StateDirectory=opentrons-audit-server
 Environment=PYTHONPATH=/opt/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_persistence_directory=/var/lib/opentrons-audit-server
+Environment=OT_AUDIT_SERVER_key_server_uds=/run/opentrons-key-server.sock
 Restart=on-failure
 TimeoutStartSec=3min
 # We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.


### PR DESCRIPTION
The audit server needs to talk to the key server to get signed logs.

Needed by https://github.com/Opentrons/opentrons/pull/21883