### PR TITLE
meta-opentrons: link auth and audit

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
@@ -15,6 +15,7 @@ StateDirectory=opentrons-audit-server
 Environment=PYTHONPATH=/opt/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_persistence_directory=/var/lib/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_key_server_uds=/run/opentrons-key-server.sock
+Environment=OT_AUDIT_SERVER_auth_server_uds=/run/opentrons-auth-server.sock
 Restart=on-failure
 TimeoutStartSec=3min
 # We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-auth-server.service
@@ -2,6 +2,8 @@
 Description=Opentrons Auth HTTP Server
 Wants=nginx.service
 After=nginx.service
+Wants=opentrons-audit-server.service
+After=opentrons-audit-server.service
 
 [Service]
 Type=notify
@@ -10,6 +12,7 @@ ExecStart=python3 -m auth_server --uds /run/opentrons-auth-server.sock
 StateDirectory=opentrons-auth-server
 Environment=PYTHONPATH=/opt/opentrons-auth-server
 Environment=OT_AUTH_SERVER_persistence_directory=/var/lib/opentrons-auth-server
+Environment=OT_AUTH_SERVER_audit_server_uds=/run/opentrons-audit-server.sock
 Restart=on-failure
 TimeoutStartSec=3min
 # We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -10,6 +10,8 @@ After=opentrons-ot3-canbus
 Wants=opentrons-pyro-nameserver.service
 After=opentrons-pyro-nameserver.service
 Wants=opentrons-hardware-api.service
+Wants=opentrons-audit-server.service
+After=opentrons-audit-server.service
 
 [Service]
 Type=notify
@@ -20,6 +22,7 @@ Environment=OT_API_FF_enableOT3HardwareController=true
 Environment=RUNNING_ON_PI=true
 Environment=PYTHONPATH=/opt/opentrons-robot-server:/usr/lib/python3.10/site-packages
 Environment=OT_ROBOT_SERVER_auth_server_uds=/run/opentrons-auth-server.sock
+Environment=OT_ROBOT_SERVER_audit_server_uds=/run/opentrons-audit-server.sock
 Environment=OT_ROBOT_SERVER_persistence_directory=%S/opentrons-robot-server
 Environment=OT_ROBOT_SERVER_images_directory=/data/images
 Environment=OT_ROBOT_SERVER_maximum_unused_protocols=20

--- a/layers/meta-opentrons/recipes-robot/opentrons-system-server/files/opentrons-system-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-system-server/files/opentrons-system-server.service
@@ -4,6 +4,8 @@ Wants=nginx.service
 After=nginx.service
 Wants=opentrons-auth-server.service
 After=opentrons-auth-server.service
+Wants=opentrons-audit-server.service
+After=opentrons-audit-server.service
 
 [Service]
 Type=notify
@@ -12,6 +14,7 @@ ExecStart=python3 -m system_server
 StateDirectory=opentrons-system-server
 Environment=PYTHONPATH=/opt/opentrons-system-server:/usr/lib/python3.10/site-packages
 Environment=OT_SYSTEM_SERVER_auth_server_uds=/run/opentrons-auth-server.sock
+Environment=OT_SYSTEM_SERVER_audit_server_uds=/run/opentrons-audit-server.sock
 Environment=OT_SYSTEM_SERVER_persistence_directory=/var/lib/opentrons-system-server
 Restart=on-failure
 TimeoutStartSec=3min

--- a/layers/meta-opentrons/recipes-robot/opentrons-update-server/files/opentrons-update-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-update-server/files/opentrons-update-server.service
@@ -4,6 +4,8 @@ Wants=nginx.service
 After=nginx.service
 Wants=opentrons-auth-server.service
 After=opentrons-auth-server.service
+Wants=opentrons-audit-server.service
+After=opentrons-audit-server.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Tired of forgetting I haven't done this yet. We have six main application servers: robot, system, update, audit, auth, and key. Key-server has no modification endpoints and doesn't need auth or audit. Update needs auth and audit, but does it in application code rather than config. Robot, system, audit, and auth all need to know about each others' domain sockets.

We also add some systemd dependencies; specifically, auth, robot, system, and update now have Wants and After on audit. Audit does not have a Want or After on auth, because then there would be a circular dependency; we'll have to deal with the fact that audit comes up before auth and thus there's some period of time when the server is up but modification routes will fail in application code.