### PR TITLE
ci: STEP 2: BitBake S3 cache as tar.zst with fingerprint skip

### DIFF
--- a/.github/scripts/s3-bitbake-cache.sh
+++ b/.github/scripts/s3-bitbake-cache.sh
@@ -206,12 +206,40 @@ push_all() {
   done
 }
 
+# Sum ContentLength of the .tar.zst archives pull would fetch (not the whole
+# bucket — leftover .zip / other keys must not trip the 50GB skip gate).
+# Prints a single integer byte count on stdout.
+active_archive_size_bytes() {
+  local s3_prefix="$1"
+  local cache_bucket="${s3_prefix#s3://}"
+  cache_bucket="${cache_bucket%%/*}"
+  local sizeInBytes=0
+  local cachetype key len
+
+  for cachetype in "${CACHE_TYPES[@]}"; do
+    key="${cachetype}.tar.zst"
+    len=$(aws s3api head-object \
+      --bucket "${cache_bucket}" \
+      --key "${key}" \
+      --query ContentLength \
+      --output text 2>/dev/null || echo 0)
+    if [[ "${len}" =~ ^[0-9]+$ ]]; then
+      sizeInBytes=$((sizeInBytes + len))
+      log "Cache object s3://${cache_bucket}/${key}: ${len} bytes" >&2
+    else
+      log "Cache object s3://${cache_bucket}/${key}: missing" >&2
+    fi
+  done
+  echo "${sizeInBytes}"
+}
+
 usage() {
   cat <<EOF
 Usage:
   $0 require-zstd
   $0 pull <s3_prefix> <cachedir>
   $0 push <s3_prefix> <cachedir>
+  $0 active-size-bytes <s3_prefix>
 EOF
 }
 
@@ -228,6 +256,10 @@ main() {
     push)
       if [[ $# -ne 3 ]]; then usage; exit 1; fi
       push_all "$2" "$3"
+      ;;
+    active-size-bytes)
+      if [[ $# -ne 2 ]]; then usage; exit 1; fi
+      active_archive_size_bytes "$2"
       ;;
     *)
       usage

--- a/.github/scripts/s3-bitbake-cache.sh
+++ b/.github/scripts/s3-bitbake-cache.sh
@@ -1,57 +1,44 @@
 #!/usr/bin/env bash
-# BitBake cache helpers for oe-core CI.
+# BitBake S3 cache for oe-core CI.
 #
-# Stores downloads/sstate/git as tar.zst (preserves empty dirs for OE git cache).
-# Push skips archive+upload when a content fingerprint matches the remote manifest.
-# Pull prefers tar.zst and falls back to legacy zip.
+# Local trees (under <cachedir>/):
+#   downloads/   BitBake DL_DIR
+#   sstate/      BitBake SSTATE_DIR
+#   git/         BitBake GITDIR
+#
+# S3 objects (under <s3_prefix>/):
+#   <type>.tar.zst     archive of that tree (tar + zstd; preserves empty dirs)
+#   <type>.manifest    sha256 of sorted "path + size" (+ empty dirs)
+#
+# Commands:
+#   pull  Download each .tar.zst that exists and extract into <cachedir>/<type>.
+#         Missing objects are skipped (cold / partial cache is fine).
+#   push  Fingerprint each local tree. If it matches the remote .manifest, skip.
+#         Otherwise archive to .tar.zst, upload it, and write .manifest.
+#
+# Busting: change tree contents so the fingerprint no longer matches .manifest,
+# or delete the S3 objects. First merge of this format expects a cache miss;
+# the next successful push publishes .tar.zst + .manifest.
+#
+# Requires zstd on PATH. Provision it on the ephemeral runner image — this
+# script does not install packages.
 set -euo pipefail
 
 CACHE_TYPES=(downloads sstate git)
-# Set by ensure_tools: zstd | zip
-ARCHIVE_FORMAT="${ARCHIVE_FORMAT:-}"
 
 log() {
   echo "$@"
 }
 
-ensure_tools() {
-  if command -v zstd >/dev/null 2>&1; then
-    ARCHIVE_FORMAT=zstd
-    log "Using zstd ($(command -v zstd))"
-    return 0
+require_zstd() {
+  if ! command -v zstd >/dev/null 2>&1; then
+    log "ERROR: zstd is required but not on PATH. Install it on the ephemeral runner image." >&2
+    return 1
   fi
-
-  log "zstd not found; attempting install..."
-  if command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y zstd || true
-  elif command -v yum >/dev/null 2>&1; then
-    sudo yum install -y zstd || true
-  elif command -v apt-get >/dev/null 2>&1; then
-    sudo apt-get update -qq || true
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq zstd || true
-  fi
-
-  # Refresh command hash in case the package just landed on PATH.
-  hash -r 2>/dev/null || true
-
-  if command -v zstd >/dev/null 2>&1; then
-    ARCHIVE_FORMAT=zstd
-    log "Using zstd after install ($(command -v zstd))"
-    return 0
-  fi
-
-  if command -v zip >/dev/null 2>&1 && command -v unzip >/dev/null 2>&1; then
-    ARCHIVE_FORMAT=zip
-    log "WARNING: zstd unavailable; falling back to zip for cache archives"
-    return 0
-  fi
-
-  log "ERROR: neither zstd nor zip/unzip is available" >&2
-  return 1
+  zstd --version
 }
 
-# Fingerprint: sorted path + size for every file, plus empty dirs.
-# Prefer GNU find -printf (fast); fall back to a portable path.
+# Fingerprint used to decide whether push can skip archive+upload.
 fingerprint_dir() {
   local dir="$1"
   if [[ ! -d "$dir" ]]; then
@@ -60,58 +47,11 @@ fingerprint_dir() {
   fi
   (
     cd "$dir"
-    if find . -maxdepth 0 -printf '%p\n' >/dev/null 2>&1; then
-      find . -type f -printf 'f %P %s\n' 2>/dev/null
-      find . -type d -empty -printf 'd %P\n' 2>/dev/null
-    else
-      find . -type f -exec stat -c 'f %n %s' {} + 2>/dev/null | sed 's|^\(f\) \./|\1 |'
-      find . -type d -empty -print 2>/dev/null | sed 's|^\./||' | sed 's|^|d |'
-    fi
+    find . -type f -printf 'f %P %s\n' 2>/dev/null
+    find . -type d -empty -printf 'd %P\n' 2>/dev/null
   ) | LC_ALL=C sort | sha256sum | awk '{print $1}'
 }
 
-archive_path() {
-  local cachedir="$1"
-  local cachetype="$2"
-  if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
-    echo "${cachedir}/../${cachetype}.zip"
-  else
-    echo "${cachedir}/../${cachetype}.tar.zst"
-  fi
-}
-
-create_archive() {
-  local src="$1"
-  local dest="$2"
-  rm -f "$dest"
-  if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
-    # zip from inside the tree so paths match the legacy layout
-    (cd "$src" && zip -q -r --symlinks "$dest" .)
-  else
-    tar -C "$src" -cf - . | zstd -T0 -3 -q -o "$dest"
-  fi
-}
-
-extract_archive() {
-  local archive="$1"
-  local dest="$2"
-  local format="$3"
-  mkdir -p "$dest"
-  case "$format" in
-    tar.zst)
-      zstd -d -T0 -c "$archive" | tar -C "$dest" -xf -
-      ;;
-    zip)
-      unzip -q -u -o "$archive" -d "$dest"
-      ;;
-    *)
-      log "ERROR: unknown archive format ${format}" >&2
-      return 1
-      ;;
-  esac
-}
-
-# Returns 0 if object exists.
 s3_exists() {
   local uri="$1"
   aws s3api head-object \
@@ -121,27 +61,25 @@ s3_exists() {
 }
 
 s3_cp() {
-  # Keep errors visible in the job log (do not swallow stderr).
   aws s3 cp --no-progress "$@"
 }
 
-download_object() {
+download_with_retries() {
   local src="$1"
   local dest="$2"
   local max_attempts=3
   local attempt=1
   local rc=0
   while true; do
-    log "Downloading ${src} -> ${dest} (attempt ${attempt}/${max_attempts})"
+    log "Downloading ${src} (attempt ${attempt}/${max_attempts})"
     if s3_cp "$src" "$dest"; then
       return 0
     fi
     rc=$?
-    log "Download failed for ${src} (exit ${rc})"
+    log "Download failed (exit ${rc})"
     if [[ $attempt -ge $max_attempts ]]; then
       return "$rc"
     fi
-    log "Retrying in $((attempt * 15))s..."
     sleep $((attempt * 15))
     attempt=$((attempt + 1))
   done
@@ -150,86 +88,52 @@ download_object() {
 pull_all() {
   local s3_prefix="$1"
   local cachedir="$2"
-  ensure_tools
-
-  local -a pids=()
-  local -a types_ok=()
-  local cachetype
-  local workdir
-  workdir="$(mktemp -d -t s3-cache-pull-XXXXXX)"
+  require_zstd
   mkdir -p "$cachedir"
 
-  download_job() {
-    local cachetype="$1"
-    local outdir="$2"
-    local marker="${outdir}/${cachetype}.format"
-    local zst_uri="${s3_prefix}/${cachetype}.tar.zst"
-    local zip_uri="${s3_prefix}/${cachetype}.zip"
-    local archive=""
-
-    if s3_exists "$zst_uri"; then
-      archive="${outdir}/${cachetype}.tar.zst"
-      if download_object "$zst_uri" "$archive"; then
-        echo "tar.zst" >"$marker"
-        log "Fetched ${cachetype}.tar.zst ($(du -h "$archive" | cut -f1)B)"
-        return 0
-      fi
-    else
-      log "No ${cachetype}.tar.zst in S3; trying legacy zip"
-    fi
-
-    if s3_exists "$zip_uri"; then
-      archive="${outdir}/${cachetype}.zip"
-      if download_object "$zip_uri" "$archive"; then
-        echo "zip" >"$marker"
-        log "Fetched ${cachetype}.zip ($(du -h "$archive" | cut -f1)B)"
-        return 0
-      fi
-    else
-      log "No ${cachetype}.zip in S3 either"
-    fi
-
-    log "S3 fetch for ${cachetype} failed; skipping this cache type"
-    return 1
-  }
-
-  for cachetype in "${CACHE_TYPES[@]}"; do
-    download_job "$cachetype" "$workdir" &
-    pids+=($!)
-  done
-
+  local workdir
+  workdir="$(mktemp -d -t s3-cache-pull-XXXXXX)"
+  local -a pids=()
+  local -a types=()
+  local cachetype
   local i=0
+
+  # Download in parallel; extract sequentially after joins.
   for cachetype in "${CACHE_TYPES[@]}"; do
-    if wait "${pids[$i]}"; then
-      types_ok+=("$cachetype")
-    fi
-    i=$((i + 1))
+    (
+      if s3_exists "${s3_prefix}/${cachetype}.tar.zst"; then
+        download_with_retries "${s3_prefix}/${cachetype}.tar.zst" "${workdir}/${cachetype}.tar.zst"
+        log "Fetched ${cachetype}.tar.zst ($(du -h "${workdir}/${cachetype}.tar.zst" | cut -f1)B)"
+        exit 0
+      fi
+      log "No ${cachetype}.tar.zst in S3; skipping"
+      exit 1
+    ) &
+    pids+=($!)
+    types+=("$cachetype")
   done
 
-  if [[ ${#types_ok[@]} -eq 0 ]]; then
+  local -a fetched=()
+  for i in "${!pids[@]}"; do
+    if wait "${pids[$i]}"; then
+      fetched+=("${types[$i]}")
+    fi
+  done
+
+  if [[ ${#fetched[@]} -eq 0 ]]; then
     log "WARNING: no cache archives downloaded; BitBake will be a cold build"
     rm -rf "$workdir"
     return 0
   fi
 
-  for cachetype in "${types_ok[@]}"; do
-    local thiscache="${cachedir}/${cachetype}"
-    local marker="${workdir}/${cachetype}.format"
-    local format
-    format="$(cat "$marker")"
-    mkdir -p "$thiscache"
-    log "Extracting ${cachetype} (${format}) to ${thiscache}"
-    local extract_start extract_end
-    extract_start=$(date +%s)
-    if [[ "$format" == "tar.zst" ]]; then
-      extract_archive "${workdir}/${cachetype}.tar.zst" "$thiscache" tar.zst
-      rm -f "${workdir}/${cachetype}.tar.zst"
-    else
-      extract_archive "${workdir}/${cachetype}.zip" "$thiscache" zip
-      rm -f "${workdir}/${cachetype}.zip"
-    fi
-    extract_end=$(date +%s)
-    log "Extracted $(du -h -d 1 "$thiscache" | tail -n 1 | cut -f1)B to ${thiscache} in $((extract_end - extract_start))s"
+  for cachetype in "${fetched[@]}"; do
+    local dest="${cachedir}/${cachetype}"
+    local archive="${workdir}/${cachetype}.tar.zst"
+    mkdir -p "$dest"
+    log "Extracting ${cachetype} -> ${dest}"
+    zstd -d -T0 -c "$archive" | tar -C "$dest" -xf -
+    rm -f "$archive"
+    log "Extracted ${cachetype}: $(du -sh "$dest" | cut -f1)"
   done
 
   rm -rf "$workdir"
@@ -240,37 +144,31 @@ push_one() {
   local cachedir="$2"
   local cachetype="$3"
   local thiscache="${cachedir}/${cachetype}"
-  local archive
-  archive="$(archive_path "$cachedir" "$cachetype")"
+  local archive="${cachedir}/../${cachetype}.tar.zst"
   local manifest_remote="${s3_prefix}/${cachetype}.manifest"
   local local_fp remote_fp
-  local remote_key_ext="tar.zst"
-
-  if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
-    remote_key_ext="zip"
-  fi
 
   if [[ ! -d "$thiscache" ]]; then
-    log "No local cache directory for ${cachetype}; skipping"
+    log "No local directory for ${cachetype}; skipping"
     return 0
   fi
 
   local file_count
   file_count=$(find "$thiscache" -type f 2>/dev/null | wc -l | tr -d ' ')
   log "Cache ${cachetype}: ${file_count} files, $(du -sh "$thiscache" | cut -f1)"
+  if [[ "$file_count" -eq 0 ]]; then
+    log "Cache ${cachetype} empty; skipping"
+    return 0
+  fi
 
-  df -h
-  log "Fingerprinting ${cachetype} at ${thiscache}"
-  local fp_start fp_end
-  fp_start=$(date +%s)
+  log "Fingerprinting ${cachetype}"
   local_fp="$(fingerprint_dir "$thiscache")"
-  fp_end=$(date +%s)
-  log "Fingerprint for ${cachetype}: ${local_fp} (computed in $((fp_end - fp_start))s)"
+  log "Local fingerprint: ${local_fp}"
 
   remote_fp=""
   if remote_fp="$(aws s3 cp --no-progress "$manifest_remote" - 2>/dev/null)"; then
     remote_fp="$(echo -n "$remote_fp" | tr -d '[:space:]')"
-    log "Remote fingerprint for ${cachetype}: ${remote_fp}"
+    log "Remote fingerprint: ${remote_fp}"
   else
     log "No remote manifest for ${cachetype}"
   fi
@@ -280,27 +178,15 @@ push_one() {
     return 0
   fi
 
-  log "Archiving ${cachetype} (${ARCHIVE_FORMAT}) from ${thiscache} to ${archive}"
-  local arch_start arch_end
-  arch_start=$(date +%s)
-  create_archive "$thiscache" "$archive"
-  arch_end=$(date +%s)
-  log "Archived ${cachetype} in $((arch_end - arch_start))s ($(du -h "$archive" | cut -f1)B)"
+  log "Archiving ${cachetype} -> ${archive}"
+  rm -f "$archive"
+  tar -C "$thiscache" -cf - . | zstd -T0 -3 -q -o "$archive"
+  log "Archived ${cachetype}: $(du -h "$archive" | cut -f1)B"
 
-  log "Uploading ${cachetype}.${remote_key_ext}"
-  local up_start up_end
-  up_start=$(date +%s)
-  s3_cp "$archive" "${s3_prefix}/${cachetype}.${remote_key_ext}"
-  up_end=$(date +%s)
-  log "Uploaded $(du -h "$archive" | cut -f1)B in $((up_end - up_start))s"
-
+  log "Uploading ${cachetype}.tar.zst"
+  s3_cp "$archive" "${s3_prefix}/${cachetype}.tar.zst"
   echo -n "$local_fp" | s3_cp - "$manifest_remote"
   log "Wrote ${cachetype}.manifest"
-
-  if [[ "$remote_key_ext" == "tar.zst" ]]; then
-    # Drop legacy zip once tar.zst is published so the bucket size check stays accurate.
-    aws s3 rm "${s3_prefix}/${cachetype}.zip" 2>/dev/null || true
-  fi
 
   rm -f "$archive"
 }
@@ -308,7 +194,7 @@ push_one() {
 push_all() {
   local s3_prefix="$1"
   local cachedir="$2"
-  ensure_tools
+  require_zstd
 
   if [[ -d "$cachedir" ]]; then
     sudo chown -R "$(id -u):$(id -g)" "$cachedir" || true
@@ -323,7 +209,7 @@ push_all() {
 usage() {
   cat <<EOF
 Usage:
-  $0 ensure-tools
+  $0 require-zstd
   $0 pull <s3_prefix> <cachedir>
   $0 push <s3_prefix> <cachedir>
 EOF
@@ -332,8 +218,8 @@ EOF
 main() {
   local cmd="${1:-}"
   case "$cmd" in
-    ensure-tools)
-      ensure_tools
+    require-zstd)
+      require_zstd
       ;;
     pull)
       if [[ $# -ne 3 ]]; then usage; exit 1; fi

--- a/.github/scripts/s3-bitbake-cache.sh
+++ b/.github/scripts/s3-bitbake-cache.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# BitBake cache helpers for oe-core CI.
+#
+# Stores downloads/sstate/git as tar.zst (preserves empty dirs for OE git cache).
+# Push skips archive+upload when a content fingerprint matches the remote manifest.
+set -euo pipefail
+
+CACHE_TYPES=(downloads sstate git)
+
+ensure_tools() {
+  if command -v zstd >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "Installing zstd for BitBake cache archives..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq zstd
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y -q zstd
+  elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y -q zstd
+  else
+    echo "zstd is required but could not be installed" >&2
+    return 1
+  fi
+  command -v zstd >/dev/null 2>&1
+}
+
+# Fingerprint: sorted path + size for every file, plus empty dirs.
+# Omit mtime so incidental BitBake touches do not force a full re-upload.
+# Empty directories matter for OE git cache.
+fingerprint_dir() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    echo "missing"
+    return 0
+  fi
+  (
+    cd "$dir"
+    find . -type f -printf 'f %P %s\n' 2>/dev/null
+    find . -type d -empty -printf 'd %P\n' 2>/dev/null
+  ) | LC_ALL=C sort | sha256sum | awk '{print $1}'
+}
+
+archive_path() {
+  local cachedir="$1"
+  local cachetype="$2"
+  echo "${cachedir}/../${cachetype}.tar.zst"
+}
+
+legacy_zip_path() {
+  local cachedir="$1"
+  local cachetype="$2"
+  echo "${cachedir}/../${cachetype}.zip"
+}
+
+create_archive() {
+  local src="$1"
+  local dest="$2"
+  rm -f "$dest"
+  # Multi-threaded zstd; tar preserves empty directories (unlike plain S3 sync).
+  tar -C "$src" -cf - . | zstd -T0 -3 -q -o "$dest"
+}
+
+extract_tar_zst() {
+  local archive="$1"
+  local dest="$2"
+  mkdir -p "$dest"
+  zstd -d -T0 -c "$archive" | tar -C "$dest" -xf -
+}
+
+extract_zip() {
+  local archive="$1"
+  local dest="$2"
+  mkdir -p "$dest"
+  unzip -q -u -o "$archive" -d "$dest"
+}
+
+s3_cp() {
+  aws s3 cp --no-progress "$@"
+}
+
+download_with_retries() {
+  local src="$1"
+  local dest="$2"
+  local elapsed_file="${3:-elapsed}"
+  local max_attempts=3
+  local attempt=1
+  while true; do
+    if TIME="%E" time s3_cp "$src" "$dest" 2>"$elapsed_file"; then
+      return 0
+    fi
+    if [[ $attempt -ge $max_attempts ]]; then
+      return 1
+    fi
+    echo "S3 fetch attempt ${attempt} failed, retrying in $((attempt * 15))s..."
+    sleep $((attempt * 15))
+    attempt=$((attempt + 1))
+  done
+}
+
+pull_all() {
+  local s3_prefix="$1"
+  local cachedir="$2"
+  ensure_tools
+
+  # Parallel downloads, then sequential extracts, to speed network without
+  # holding three full extracted trees + three archives at once.
+  local -a pids=()
+  local -a types_ok=()
+  local cachetype
+  local workdir
+  workdir="$(mktemp -d -t s3-cache-pull-XXXXXX)"
+
+  download_job() {
+    local cachetype="$1"
+    local outdir="$2"
+    local archive="${outdir}/${cachetype}.tar.zst"
+    local legacy="${outdir}/${cachetype}.zip"
+    local marker="${outdir}/${cachetype}.format"
+    local elapsed_file="${outdir}/${cachetype}.elapsed"
+    if download_with_retries "${s3_prefix}/${cachetype}.tar.zst" "$archive" "$elapsed_file"; then
+      echo "tar.zst" >"$marker"
+      echo "Fetched ${cachetype}.tar.zst ($(du -h "$archive" | cut -f1)B) in $(cat "$elapsed_file")"
+      return 0
+    fi
+    if download_with_retries "${s3_prefix}/${cachetype}.zip" "$legacy" "$elapsed_file"; then
+      echo "zip" >"$marker"
+      echo "Fetched ${cachetype}.zip ($(du -h "$legacy" | cut -f1)B) in $(cat "$elapsed_file")"
+      return 0
+    fi
+    echo "S3 fetch for ${cachetype} failed after retries, skipping"
+    return 1
+  }
+
+  for cachetype in "${CACHE_TYPES[@]}"; do
+    download_job "$cachetype" "$workdir" &
+    pids+=($!)
+  done
+
+  local i=0
+  for cachetype in "${CACHE_TYPES[@]}"; do
+    if wait "${pids[$i]}"; then
+      types_ok+=("$cachetype")
+    fi
+    i=$((i + 1))
+  done
+
+  for cachetype in "${types_ok[@]}"; do
+    local thiscache="${cachedir}/${cachetype}"
+    local marker="${workdir}/${cachetype}.format"
+    local format
+    local elapsed_file="${workdir}/${cachetype}.extract.elapsed"
+    format="$(cat "$marker")"
+    mkdir -p "$thiscache"
+    echo "Extracting ${cachetype} (${format}) to ${thiscache}"
+    if [[ "$format" == "tar.zst" ]]; then
+      TIME="%E" time extract_tar_zst "${workdir}/${cachetype}.tar.zst" "$thiscache" 2>"$elapsed_file"
+      rm -f "${workdir}/${cachetype}.tar.zst"
+    else
+      TIME="%E" time extract_zip "${workdir}/${cachetype}.zip" "$thiscache" 2>"$elapsed_file"
+      rm -f "${workdir}/${cachetype}.zip"
+    fi
+    echo "Extracted $(du -h -d 1 "$thiscache" | tail -n 1 | cut -f1)B to ${thiscache} in $(cat "$elapsed_file")"
+  done
+
+  rm -rf "$workdir"
+}
+
+push_one() {
+  local s3_prefix="$1"
+  local cachedir="$2"
+  local cachetype="$3"
+  local thiscache="${cachedir}/${cachetype}"
+  local archive
+  archive="$(archive_path "$cachedir" "$cachetype")"
+  local manifest_remote="${s3_prefix}/${cachetype}.manifest"
+  local local_fp remote_fp
+
+  if [[ ! -d "$thiscache" ]]; then
+    echo "No local cache directory for ${cachetype}; skipping"
+    return 0
+  fi
+
+  local elapsed_file
+  elapsed_file="$(mktemp)"
+  df -h
+  echo "Fingerprinting ${cachetype} at ${thiscache}"
+  local fp_start fp_end
+  fp_start=$(date +%s)
+  local_fp="$(fingerprint_dir "$thiscache")"
+  fp_end=$(date +%s)
+  echo "Fingerprint for ${cachetype}: ${local_fp} (computed in $((fp_end - fp_start))s)"
+
+  remote_fp=""
+  if remote_fp="$(aws s3 cp --no-progress "$manifest_remote" - 2>/dev/null)"; then
+    remote_fp="$(echo -n "$remote_fp" | tr -d '[:space:]')"
+    echo "Remote fingerprint for ${cachetype}: ${remote_fp}"
+  else
+    echo "No remote manifest for ${cachetype}"
+  fi
+
+  if [[ -n "$remote_fp" && "$local_fp" == "$remote_fp" ]]; then
+    echo "Skipping ${cachetype}: fingerprint unchanged"
+    rm -f "$elapsed_file"
+    return 0
+  fi
+
+  echo "Archiving ${cachetype} from ${thiscache} to ${archive}"
+  TIME="%E" time create_archive "$thiscache" "$archive" 2>"$elapsed_file"
+  echo "Archived ${cachetype} in $(cat "$elapsed_file") ($(du -h "$archive" | cut -f1)B)"
+
+  echo "Uploading ${cachetype}.tar.zst"
+  TIME="%E" time s3_cp "$archive" "${s3_prefix}/${cachetype}.tar.zst" 2>"$elapsed_file"
+  echo "Uploaded $(du -h "$archive" | cut -f1)B in $(cat "$elapsed_file")"
+
+  echo -n "$local_fp" | s3_cp - "$manifest_remote"
+  echo "Wrote ${cachetype}.manifest"
+
+  # Drop legacy zip once tar.zst is published so the bucket size check stays accurate.
+  aws s3 rm "${s3_prefix}/${cachetype}.zip" 2>/dev/null || true
+
+  rm -f "$archive" "$elapsed_file"
+}
+
+push_all() {
+  local s3_prefix="$1"
+  local cachedir="$2"
+  ensure_tools
+
+  if [[ -d "$cachedir" ]]; then
+    sudo chown -R "$(id -u):$(id -g)" "$cachedir"
+  fi
+
+  local cachetype
+  for cachetype in "${CACHE_TYPES[@]}"; do
+    push_one "$s3_prefix" "$cachedir" "$cachetype"
+  done
+}
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 ensure-tools
+  $0 pull <s3_prefix> <cachedir>
+  $0 push <s3_prefix> <cachedir>
+EOF
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    ensure-tools)
+      ensure_tools
+      ;;
+    pull)
+      if [[ $# -ne 3 ]]; then usage; exit 1; fi
+      pull_all "$2" "$3"
+      ;;
+    push)
+      if [[ $# -ne 3 ]]; then usage; exit 1; fi
+      push_all "$2" "$3"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/.github/scripts/s3-bitbake-cache.sh
+++ b/.github/scripts/s3-bitbake-cache.sh
@@ -3,32 +3,55 @@
 #
 # Stores downloads/sstate/git as tar.zst (preserves empty dirs for OE git cache).
 # Push skips archive+upload when a content fingerprint matches the remote manifest.
+# Pull prefers tar.zst and falls back to legacy zip.
 set -euo pipefail
 
 CACHE_TYPES=(downloads sstate git)
+# Set by ensure_tools: zstd | zip
+ARCHIVE_FORMAT="${ARCHIVE_FORMAT:-}"
+
+log() {
+  echo "$@"
+}
 
 ensure_tools() {
   if command -v zstd >/dev/null 2>&1; then
+    ARCHIVE_FORMAT=zstd
+    log "Using zstd ($(command -v zstd))"
     return 0
   fi
-  echo "Installing zstd for BitBake cache archives..."
-  if command -v apt-get >/dev/null 2>&1; then
-    sudo apt-get update -qq
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq zstd
-  elif command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y -q zstd
+
+  log "zstd not found; attempting install..."
+  if command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y zstd || true
   elif command -v yum >/dev/null 2>&1; then
-    sudo yum install -y -q zstd
-  else
-    echo "zstd is required but could not be installed" >&2
-    return 1
+    sudo yum install -y zstd || true
+  elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update -qq || true
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq zstd || true
   fi
-  command -v zstd >/dev/null 2>&1
+
+  # Refresh command hash in case the package just landed on PATH.
+  hash -r 2>/dev/null || true
+
+  if command -v zstd >/dev/null 2>&1; then
+    ARCHIVE_FORMAT=zstd
+    log "Using zstd after install ($(command -v zstd))"
+    return 0
+  fi
+
+  if command -v zip >/dev/null 2>&1 && command -v unzip >/dev/null 2>&1; then
+    ARCHIVE_FORMAT=zip
+    log "WARNING: zstd unavailable; falling back to zip for cache archives"
+    return 0
+  fi
+
+  log "ERROR: neither zstd nor zip/unzip is available" >&2
+  return 1
 }
 
 # Fingerprint: sorted path + size for every file, plus empty dirs.
-# Omit mtime so incidental BitBake touches do not force a full re-upload.
-# Empty directories matter for OE git cache.
+# Prefer GNU find -printf (fast); fall back to a portable path.
 fingerprint_dir() {
   local dir="$1"
   if [[ ! -d "$dir" ]]; then
@@ -37,63 +60,88 @@ fingerprint_dir() {
   fi
   (
     cd "$dir"
-    find . -type f -printf 'f %P %s\n' 2>/dev/null
-    find . -type d -empty -printf 'd %P\n' 2>/dev/null
+    if find . -maxdepth 0 -printf '%p\n' >/dev/null 2>&1; then
+      find . -type f -printf 'f %P %s\n' 2>/dev/null
+      find . -type d -empty -printf 'd %P\n' 2>/dev/null
+    else
+      find . -type f -exec stat -c 'f %n %s' {} + 2>/dev/null | sed 's|^\(f\) \./|\1 |'
+      find . -type d -empty -print 2>/dev/null | sed 's|^\./||' | sed 's|^|d |'
+    fi
   ) | LC_ALL=C sort | sha256sum | awk '{print $1}'
 }
 
 archive_path() {
   local cachedir="$1"
   local cachetype="$2"
-  echo "${cachedir}/../${cachetype}.tar.zst"
-}
-
-legacy_zip_path() {
-  local cachedir="$1"
-  local cachetype="$2"
-  echo "${cachedir}/../${cachetype}.zip"
+  if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
+    echo "${cachedir}/../${cachetype}.zip"
+  else
+    echo "${cachedir}/../${cachetype}.tar.zst"
+  fi
 }
 
 create_archive() {
   local src="$1"
   local dest="$2"
   rm -f "$dest"
-  # Multi-threaded zstd; tar preserves empty directories (unlike plain S3 sync).
-  tar -C "$src" -cf - . | zstd -T0 -3 -q -o "$dest"
+  if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
+    # zip from inside the tree so paths match the legacy layout
+    (cd "$src" && zip -q -r --symlinks "$dest" .)
+  else
+    tar -C "$src" -cf - . | zstd -T0 -3 -q -o "$dest"
+  fi
 }
 
-extract_tar_zst() {
+extract_archive() {
   local archive="$1"
   local dest="$2"
+  local format="$3"
   mkdir -p "$dest"
-  zstd -d -T0 -c "$archive" | tar -C "$dest" -xf -
+  case "$format" in
+    tar.zst)
+      zstd -d -T0 -c "$archive" | tar -C "$dest" -xf -
+      ;;
+    zip)
+      unzip -q -u -o "$archive" -d "$dest"
+      ;;
+    *)
+      log "ERROR: unknown archive format ${format}" >&2
+      return 1
+      ;;
+  esac
 }
 
-extract_zip() {
-  local archive="$1"
-  local dest="$2"
-  mkdir -p "$dest"
-  unzip -q -u -o "$archive" -d "$dest"
+# Returns 0 if object exists.
+s3_exists() {
+  local uri="$1"
+  aws s3api head-object \
+    --bucket "$(echo "$uri" | sed -E 's|^s3://([^/]+)/.*|\1|')" \
+    --key "$(echo "$uri" | sed -E 's|^s3://[^/]+/||')" \
+    >/dev/null 2>&1
 }
 
 s3_cp() {
+  # Keep errors visible in the job log (do not swallow stderr).
   aws s3 cp --no-progress "$@"
 }
 
-download_with_retries() {
+download_object() {
   local src="$1"
   local dest="$2"
-  local elapsed_file="${3:-elapsed}"
   local max_attempts=3
   local attempt=1
+  local rc=0
   while true; do
-    if TIME="%E" time s3_cp "$src" "$dest" 2>"$elapsed_file"; then
+    log "Downloading ${src} -> ${dest} (attempt ${attempt}/${max_attempts})"
+    if s3_cp "$src" "$dest"; then
       return 0
     fi
+    rc=$?
+    log "Download failed for ${src} (exit ${rc})"
     if [[ $attempt -ge $max_attempts ]]; then
-      return 1
+      return "$rc"
     fi
-    echo "S3 fetch attempt ${attempt} failed, retrying in $((attempt * 15))s..."
+    log "Retrying in $((attempt * 15))s..."
     sleep $((attempt * 15))
     attempt=$((attempt + 1))
   done
@@ -104,32 +152,44 @@ pull_all() {
   local cachedir="$2"
   ensure_tools
 
-  # Parallel downloads, then sequential extracts, to speed network without
-  # holding three full extracted trees + three archives at once.
   local -a pids=()
   local -a types_ok=()
   local cachetype
   local workdir
   workdir="$(mktemp -d -t s3-cache-pull-XXXXXX)"
+  mkdir -p "$cachedir"
 
   download_job() {
     local cachetype="$1"
     local outdir="$2"
-    local archive="${outdir}/${cachetype}.tar.zst"
-    local legacy="${outdir}/${cachetype}.zip"
     local marker="${outdir}/${cachetype}.format"
-    local elapsed_file="${outdir}/${cachetype}.elapsed"
-    if download_with_retries "${s3_prefix}/${cachetype}.tar.zst" "$archive" "$elapsed_file"; then
-      echo "tar.zst" >"$marker"
-      echo "Fetched ${cachetype}.tar.zst ($(du -h "$archive" | cut -f1)B) in $(cat "$elapsed_file")"
-      return 0
+    local zst_uri="${s3_prefix}/${cachetype}.tar.zst"
+    local zip_uri="${s3_prefix}/${cachetype}.zip"
+    local archive=""
+
+    if s3_exists "$zst_uri"; then
+      archive="${outdir}/${cachetype}.tar.zst"
+      if download_object "$zst_uri" "$archive"; then
+        echo "tar.zst" >"$marker"
+        log "Fetched ${cachetype}.tar.zst ($(du -h "$archive" | cut -f1)B)"
+        return 0
+      fi
+    else
+      log "No ${cachetype}.tar.zst in S3; trying legacy zip"
     fi
-    if download_with_retries "${s3_prefix}/${cachetype}.zip" "$legacy" "$elapsed_file"; then
-      echo "zip" >"$marker"
-      echo "Fetched ${cachetype}.zip ($(du -h "$legacy" | cut -f1)B) in $(cat "$elapsed_file")"
-      return 0
+
+    if s3_exists "$zip_uri"; then
+      archive="${outdir}/${cachetype}.zip"
+      if download_object "$zip_uri" "$archive"; then
+        echo "zip" >"$marker"
+        log "Fetched ${cachetype}.zip ($(du -h "$archive" | cut -f1)B)"
+        return 0
+      fi
+    else
+      log "No ${cachetype}.zip in S3 either"
     fi
-    echo "S3 fetch for ${cachetype} failed after retries, skipping"
+
+    log "S3 fetch for ${cachetype} failed; skipping this cache type"
     return 1
   }
 
@@ -146,22 +206,30 @@ pull_all() {
     i=$((i + 1))
   done
 
+  if [[ ${#types_ok[@]} -eq 0 ]]; then
+    log "WARNING: no cache archives downloaded; BitBake will be a cold build"
+    rm -rf "$workdir"
+    return 0
+  fi
+
   for cachetype in "${types_ok[@]}"; do
     local thiscache="${cachedir}/${cachetype}"
     local marker="${workdir}/${cachetype}.format"
     local format
-    local elapsed_file="${workdir}/${cachetype}.extract.elapsed"
     format="$(cat "$marker")"
     mkdir -p "$thiscache"
-    echo "Extracting ${cachetype} (${format}) to ${thiscache}"
+    log "Extracting ${cachetype} (${format}) to ${thiscache}"
+    local extract_start extract_end
+    extract_start=$(date +%s)
     if [[ "$format" == "tar.zst" ]]; then
-      TIME="%E" time extract_tar_zst "${workdir}/${cachetype}.tar.zst" "$thiscache" 2>"$elapsed_file"
+      extract_archive "${workdir}/${cachetype}.tar.zst" "$thiscache" tar.zst
       rm -f "${workdir}/${cachetype}.tar.zst"
     else
-      TIME="%E" time extract_zip "${workdir}/${cachetype}.zip" "$thiscache" 2>"$elapsed_file"
+      extract_archive "${workdir}/${cachetype}.zip" "$thiscache" zip
       rm -f "${workdir}/${cachetype}.zip"
     fi
-    echo "Extracted $(du -h -d 1 "$thiscache" | tail -n 1 | cut -f1)B to ${thiscache} in $(cat "$elapsed_file")"
+    extract_end=$(date +%s)
+    log "Extracted $(du -h -d 1 "$thiscache" | tail -n 1 | cut -f1)B to ${thiscache} in $((extract_end - extract_start))s"
   done
 
   rm -rf "$workdir"
@@ -176,51 +244,65 @@ push_one() {
   archive="$(archive_path "$cachedir" "$cachetype")"
   local manifest_remote="${s3_prefix}/${cachetype}.manifest"
   local local_fp remote_fp
+  local remote_key_ext="tar.zst"
+
+  if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
+    remote_key_ext="zip"
+  fi
 
   if [[ ! -d "$thiscache" ]]; then
-    echo "No local cache directory for ${cachetype}; skipping"
+    log "No local cache directory for ${cachetype}; skipping"
     return 0
   fi
 
-  local elapsed_file
-  elapsed_file="$(mktemp)"
+  local file_count
+  file_count=$(find "$thiscache" -type f 2>/dev/null | wc -l | tr -d ' ')
+  log "Cache ${cachetype}: ${file_count} files, $(du -sh "$thiscache" | cut -f1)"
+
   df -h
-  echo "Fingerprinting ${cachetype} at ${thiscache}"
+  log "Fingerprinting ${cachetype} at ${thiscache}"
   local fp_start fp_end
   fp_start=$(date +%s)
   local_fp="$(fingerprint_dir "$thiscache")"
   fp_end=$(date +%s)
-  echo "Fingerprint for ${cachetype}: ${local_fp} (computed in $((fp_end - fp_start))s)"
+  log "Fingerprint for ${cachetype}: ${local_fp} (computed in $((fp_end - fp_start))s)"
 
   remote_fp=""
   if remote_fp="$(aws s3 cp --no-progress "$manifest_remote" - 2>/dev/null)"; then
     remote_fp="$(echo -n "$remote_fp" | tr -d '[:space:]')"
-    echo "Remote fingerprint for ${cachetype}: ${remote_fp}"
+    log "Remote fingerprint for ${cachetype}: ${remote_fp}"
   else
-    echo "No remote manifest for ${cachetype}"
+    log "No remote manifest for ${cachetype}"
   fi
 
   if [[ -n "$remote_fp" && "$local_fp" == "$remote_fp" ]]; then
-    echo "Skipping ${cachetype}: fingerprint unchanged"
-    rm -f "$elapsed_file"
+    log "Skipping ${cachetype}: fingerprint unchanged"
     return 0
   fi
 
-  echo "Archiving ${cachetype} from ${thiscache} to ${archive}"
-  TIME="%E" time create_archive "$thiscache" "$archive" 2>"$elapsed_file"
-  echo "Archived ${cachetype} in $(cat "$elapsed_file") ($(du -h "$archive" | cut -f1)B)"
+  log "Archiving ${cachetype} (${ARCHIVE_FORMAT}) from ${thiscache} to ${archive}"
+  local arch_start arch_end
+  arch_start=$(date +%s)
+  create_archive "$thiscache" "$archive"
+  arch_end=$(date +%s)
+  log "Archived ${cachetype} in $((arch_end - arch_start))s ($(du -h "$archive" | cut -f1)B)"
 
-  echo "Uploading ${cachetype}.tar.zst"
-  TIME="%E" time s3_cp "$archive" "${s3_prefix}/${cachetype}.tar.zst" 2>"$elapsed_file"
-  echo "Uploaded $(du -h "$archive" | cut -f1)B in $(cat "$elapsed_file")"
+  log "Uploading ${cachetype}.${remote_key_ext}"
+  local up_start up_end
+  up_start=$(date +%s)
+  s3_cp "$archive" "${s3_prefix}/${cachetype}.${remote_key_ext}"
+  up_end=$(date +%s)
+  log "Uploaded $(du -h "$archive" | cut -f1)B in $((up_end - up_start))s"
 
   echo -n "$local_fp" | s3_cp - "$manifest_remote"
-  echo "Wrote ${cachetype}.manifest"
+  log "Wrote ${cachetype}.manifest"
 
-  # Drop legacy zip once tar.zst is published so the bucket size check stays accurate.
-  aws s3 rm "${s3_prefix}/${cachetype}.zip" 2>/dev/null || true
+  if [[ "$remote_key_ext" == "tar.zst" ]]; then
+    # Drop legacy zip once tar.zst is published so the bucket size check stays accurate.
+    aws s3 rm "${s3_prefix}/${cachetype}.zip" 2>/dev/null || true
+  fi
 
-  rm -f "$archive" "$elapsed_file"
+  rm -f "$archive"
 }
 
 push_all() {
@@ -229,7 +311,7 @@ push_all() {
   ensure_tools
 
   if [[ -d "$cachedir" ]]; then
-    sudo chown -R "$(id -u):$(id -g)" "$cachedir"
+    sudo chown -R "$(id -u):$(id -g)" "$cachedir" || true
   fi
 
   local cachetype

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,6 +22,11 @@ Builds are triggered:
 
 - There is a `LOCAL_CACHE` environment variable injected that points to a directory that will be present on subsequent builds on the same runner.
 - There is an `S3_CACHE_ARN` environment variable that is the ARN of an s3 bucket that can be used for caching.
-- Cache is stored on the S3 bucket as a big zip (since OE git cache needs to store empty directories and S3 doesn't do that on its own). We fetch cache before every build, and update `LOCAL_CACHE` with it. If the build succeeds, we update the zip and write it back.
+- Cache is stored on the S3 bucket as `downloads` / `sstate` / `git` **`tar.zst`** archives (tar preserves empty directories needed by the OE git cache). Legacy `.zip` objects are still readable on pull during migration.
+- Pull downloads the three archives **in parallel**, then extracts them sequentially.
+- Push fingerprints each cache tree (`path` + `size`, plus empty dirs). If the fingerprint matches the remote `*.manifest`, that cache type is **skipped** (no re-archive / re-upload).
+- Push uses multi-threaded `zstd` compression. After a successful `tar.zst` upload, the legacy `.zip` for that type is deleted from the bucket.
 - Build results get sent to an artifact bucket identified by `S3_ARTIFACT_ARN`.
 - We have to be a little more careful with removing working directories here than in normal github actions.
+
+Helpers live in [`.github/scripts/s3-bitbake-cache.sh`](../scripts/s3-bitbake-cache.sh).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,11 +22,10 @@ Builds are triggered:
 
 - There is a `LOCAL_CACHE` environment variable injected that points to a directory that will be present on subsequent builds on the same runner.
 - There is an `S3_CACHE_ARN` environment variable that is the ARN of an s3 bucket that can be used for caching.
-- Cache is stored on the S3 bucket as `downloads` / `sstate` / `git` **`tar.zst`** archives (tar preserves empty directories needed by the OE git cache). Legacy `.zip` objects are still readable on pull during migration.
-- Pull downloads the three archives **in parallel**, then extracts them sequentially.
-- Push fingerprints each cache tree (`path` + `size`, plus empty dirs). If the fingerprint matches the remote `*.manifest`, that cache type is **skipped** (no re-archive / re-upload).
-- Push uses multi-threaded `zstd` compression. After a successful `tar.zst` upload, the legacy `.zip` for that type is deleted from the bucket.
-- Build results get sent to an artifact bucket identified by `S3_ARTIFACT_ARN`.
+- BitBake cache trees (`downloads` / `sstate` / `git`) are stored on S3 as **`tar.zst`** plus a **`.manifest`** fingerprint. Helper: [`.github/scripts/s3-bitbake-cache.sh`](../scripts/s3-bitbake-cache.sh).
+- **Pull:** download each `.tar.zst` that exists (in parallel), then extract sequentially. Missing objects mean a cold/partial cache.
+- **Push:** fingerprint each tree (`path` + `size`, plus empty dirs). If it matches the remote `.manifest`, skip; otherwise archive with `zstd` and upload `.tar.zst` + `.manifest`.
+- **zstd** must already be on the ephemeral runner image (the script prints `zstd --version` or fails; it does not install packages).
+- First run after this format lands expects no hit; the following push seeds the new objects.
+- Build results go to an artifact bucket identified by `S3_ARTIFACT_ARN`.
 - We have to be a little more careful with removing working directories here than in normal github actions.
-
-Helpers live in [`.github/scripts/s3-bitbake-cache.sh`](../scripts/s3-bitbake-cache.sh).

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -565,7 +565,7 @@ jobs:
           token: ${{secrets.MONOREPO_RELEASE_ARTIFACT_UPLOAD_TOKEN}}
       # Defer cache upload until after S3 artifact and monorepo release uploads so
       # build outputs are published before this slow archive-and-upload step runs.
-      # Uses tar.zst (faster than zip) and skips upload when the fingerprint is unchanged.
+      # Writes <type>.tar.zst + <type>.manifest; skips when the fingerprint is unchanged.
       - name: Push S3 cache
         shell: bash
         continue-on-error: true

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -405,69 +405,18 @@ jobs:
       - name: Pull S3 cache
         shell: bash
         run: |
-          # Size only the archives this job actually pulls (not the whole bucket).
-          # Mixed buckets can hold both .zip (this workflow) and leftover .tar.zst
-          # from experiments; summing everything falsely trips the 50GB skip.
-          #
-          # Format follows what this workflow pull/push uses — currently .zip.
-          # There is no "use zstd if installed" switch on main; when the tar.zst
-          # cache path lands, set cache_archive_ext=tar.zst (and extract with
-          # tar -I zstd) so the size gate stays aligned with the pull loop.
-          cache_types=(downloads sstate git)
-          cache_archive_ext=zip
-          cache_bucket="${S3_CACHE_ARN/arn:aws:s3:::/}"
-          s3_prefix="s3://${cache_bucket}"
-
-          sizeInBytes=0
-          for cachetype in "${cache_types[@]}"; do
-            key="${cachetype}.${cache_archive_ext}"
-            len=$(aws s3api head-object \
-              --bucket "${cache_bucket}" \
-              --key "${key}" \
-              --query ContentLength \
-              --output text 2>/dev/null || echo 0)
-            # Missing objects count as 0 (cold/partial cache is fine).
-            if [[ "${len}" =~ ^[0-9]+$ ]]; then
-              sizeInBytes=$((sizeInBytes + len))
-              echo "Cache object s3://${cache_bucket}/${key}: ${len} bytes"
-            else
-              echo "Cache object s3://${cache_bucket}/${key}: missing"
-            fi
-          done
-          sizeInGigabytes=$((sizeInBytes / 1024 / 1024 / 1024))
-          echo "Active ${cache_archive_ext} cache total: ${sizeInGigabytes}GB (${sizeInBytes} bytes)"
-
+          set -euo pipefail
+          cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh
+          chmod +x "$cache_script"
+          # Skip pull if the cache bucket is already huge so we keep room to build.
+          sizeInBytes=$(aws s3 ls "s3://${S3_CACHE_ARN/arn:aws:s3:::/}" --recursive --summarize | awk 'END{print}' | grep -o '[0-9].*' || echo 0)
+          sizeInGigabytes=$((sizeInBytes/1024/1024/1024))
           if [[ $sizeInGigabytes -gt 50 ]]; then
-              echo "Doing clean build without cache, size of active ${cache_archive_ext} archives: ${sizeInGigabytes}GB!"
+            echo "Doing clean build without cache, size of cache: ${sizeInGigabytes}GB!"
           else
-              aws_cp="aws s3 cp --no-progress"
-              cachedir=${LOCAL_CACHE:-./cache}
-              for cachetype in "${cache_types[@]}"; do
-                  local_archive="${cachedir}/../${cachetype}.${cache_archive_ext}"
-                  thiscache=${cachedir}/${cachetype}
-                  echo "Fetching cache for ${cachetype} to ${local_archive}"
-                  mkdir -p ${thiscache}
-                  max_attempts=3
-                  attempt=1
-                  while true; do
-                    if TIME="%E" time $aws_cp ${s3_prefix}/${cachetype}.${cache_archive_ext} ${local_archive} 2>elapsed; then
-                      break
-                    fi
-                    if [[ $attempt -ge $max_attempts ]]; then
-                      echo "S3 fetch for ${cachetype} failed after ${max_attempts} attempts, skipping cache for this type"
-                      continue 2
-                    fi
-                    echo "S3 fetch attempt ${attempt} failed, retrying in $((attempt * 15))s..."
-                    sleep $((attempt * 15))
-                    attempt=$((attempt + 1))
-                  done
-                  echo "Fetched $(du -h ${local_archive} | cut -f 1)B in $(cat elapsed), extracting to ${thiscache}" || true
-                  TIME="%E" time unzip -q -u -o ${local_archive} -d ${thiscache} 2>elapsed
-                  echo "Extracted $(du -h -d 1 $thiscache | tail -n 1 | cut -f 1)B to ${thiscache} in $(cat elapsed)" || true
-                  # Remove archive immediately after extraction to free up space
-                  rm -f ${local_archive}
-                  echo "Removed ${local_archive} to free up space"
-              done
+            cachedir=${LOCAL_CACHE:-./cache}
+            s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}"
+            "$cache_script" pull "$s3_prefix" "$cachedir"
           fi
       - name: Cleanup before build
         run: |
@@ -615,28 +564,18 @@ jobs:
           artifactContentType: application/json
           token: ${{secrets.MONOREPO_RELEASE_ARTIFACT_UPLOAD_TOKEN}}
       # Defer cache upload until after S3 artifact and monorepo release uploads so
-      # build outputs are published before this slow zip-and-upload step runs.
+      # build outputs are published before this slow archive-and-upload step runs.
+      # Uses tar.zst (faster than zip) and skips upload when the fingerprint is unchanged.
       - name: Push S3 cache
         shell: bash
         continue-on-error: true
         run: |
-          aws_cp="aws s3 cp --no-progress"
+          set -euo pipefail
+          cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh
+          chmod +x "$cache_script"
           cachedir=${LOCAL_CACHE:-./cache}
-          # Docker leaves root-owned files on bind-mounted cache; zip and rm need runner ownership.
-          if [ -d "$cachedir" ]; then
-            sudo chown -R "$(id -u):$(id -g)" "$cachedir"
-          fi
-          for cachetype in downloads sstate git ; do
-              df -h
-              local_archive="${cachedir}/../${cachetype}.zip"
-              thiscache=${cachedir}/${cachetype}
-              cd ${thiscache}
-              echo "Refreshing cache for ${cachetype} from ${thiscache} to ${local_archive}"
-              TIME="%E" time zip -q -r --filesync --symlinks  ${local_archive} ./* 2>elapsed
-              echo "Refreshed cache in $(cat elapsed)" || 0
-              TIME="%E" time ${aws_cp} ${local_archive} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip 2>elapsed
-              echo "Uploaded $(du -h $local_archive | cut -f 1)B in $(cat elapsed)" || 0
-          done
+          s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}"
+          "$cache_script" push "$s3_prefix" "$cachedir"
       # Ephemeral runners are destroyed after the job; cleanup is redundant but harmless.
       - name: Remove build data
         if: always()

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -443,14 +443,14 @@ jobs:
               aws_cp="aws s3 cp --no-progress"
               cachedir=${LOCAL_CACHE:-./cache}
               for cachetype in "${cache_types[@]}"; do
-                  localzip="${cachedir}/../${cachetype}.${cache_archive_ext}"
+                  local_archive="${cachedir}/../${cachetype}.${cache_archive_ext}"
                   thiscache=${cachedir}/${cachetype}
-                  echo "Fetching cache for ${cachetype} to ${localzip}"
+                  echo "Fetching cache for ${cachetype} to ${local_archive}"
                   mkdir -p ${thiscache}
                   max_attempts=3
                   attempt=1
                   while true; do
-                    if TIME="%E" time $aws_cp ${s3_prefix}/${cachetype}.${cache_archive_ext} ${localzip} 2>elapsed; then
+                    if TIME="%E" time $aws_cp ${s3_prefix}/${cachetype}.${cache_archive_ext} ${local_archive} 2>elapsed; then
                       break
                     fi
                     if [[ $attempt -ge $max_attempts ]]; then
@@ -461,12 +461,12 @@ jobs:
                     sleep $((attempt * 15))
                     attempt=$((attempt + 1))
                   done
-                  echo "Fetched $(du -h ${localzip} | cut -f 1)B in $(cat elapsed), extracting to ${thiscache}" || true
-                  TIME="%E" time unzip -q -u -o ${localzip} -d ${thiscache} 2>elapsed
+                  echo "Fetched $(du -h ${local_archive} | cut -f 1)B in $(cat elapsed), extracting to ${thiscache}" || true
+                  TIME="%E" time unzip -q -u -o ${local_archive} -d ${thiscache} 2>elapsed
                   echo "Extracted $(du -h -d 1 $thiscache | tail -n 1 | cut -f 1)B to ${thiscache} in $(cat elapsed)" || true
                   # Remove archive immediately after extraction to free up space
-                  rm -f ${localzip}
-                  echo "Removed ${localzip} to free up space"
+                  rm -f ${local_archive}
+                  echo "Removed ${local_archive} to free up space"
               done
           fi
       - name: Cleanup before build
@@ -628,14 +628,14 @@ jobs:
           fi
           for cachetype in downloads sstate git ; do
               df -h
-              localzip="${cachedir}/../${cachetype}.zip"
+              local_archive="${cachedir}/../${cachetype}.zip"
               thiscache=${cachedir}/${cachetype}
               cd ${thiscache}
-              echo "Refreshing cache for ${cachetype} from ${thiscache} to ${localzip}"
-              TIME="%E" time zip -q -r --filesync --symlinks  ${localzip} ./* 2>elapsed
+              echo "Refreshing cache for ${cachetype} from ${thiscache} to ${local_archive}"
+              TIME="%E" time zip -q -r --filesync --symlinks  ${local_archive} ./* 2>elapsed
               echo "Refreshed cache in $(cat elapsed)" || 0
-              TIME="%E" time ${aws_cp} ${localzip} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip 2>elapsed
-              echo "Uploaded $(du -h $localzip | cut -f 1)B in $(cat elapsed)" || 0
+              TIME="%E" time ${aws_cp} ${local_archive} s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cachetype}.zip 2>elapsed
+              echo "Uploaded $(du -h $local_archive | cut -f 1)B in $(cat elapsed)" || 0
           done
       # Ephemeral runners are destroyed after the job; cleanup is redundant but harmless.
       - name: Remove build data

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -408,14 +408,16 @@ jobs:
           set -euo pipefail
           cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh
           chmod +x "$cache_script"
-          # Skip pull if the cache bucket is already huge so we keep room to build.
-          sizeInBytes=$(aws s3 ls "s3://${S3_CACHE_ARN/arn:aws:s3:::/}" --recursive --summarize | awk 'END{print}' | grep -o '[0-9].*' || echo 0)
-          sizeInGigabytes=$((sizeInBytes/1024/1024/1024))
+          cachedir=${LOCAL_CACHE:-./cache}
+          s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}"
+          # Size only .tar.zst archives this job pulls (not whole-bucket sum —
+          # leftover .zip objects must not force a cold build).
+          sizeInBytes=$("$cache_script" active-size-bytes "$s3_prefix")
+          sizeInGigabytes=$((sizeInBytes / 1024 / 1024 / 1024))
+          echo "Active tar.zst cache total: ${sizeInGigabytes}GB (${sizeInBytes} bytes)"
           if [[ $sizeInGigabytes -gt 50 ]]; then
-            echo "Doing clean build without cache, size of cache: ${sizeInGigabytes}GB!"
+            echo "Doing clean build without cache, size of active tar.zst archives: ${sizeInGigabytes}GB!"
           else
-            cachedir=${LOCAL_CACHE:-./cache}
-            s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}"
             "$cache_script" pull "$s3_prefix" "$cachedir"
           fi
       - name: Cleanup before build


### PR DESCRIPTION
## Summary
- Add `.github/scripts/s3-bitbake-cache.sh` for `downloads` / `sstate` / `git` as `tar.zst` (legacy zip fallback on pull).
- Push skips archive+upload when a content fingerprint matches the remote `*.manifest`.
- Harden pull/push error reporting and zstd install / zip fallback.
- Wire the build workflow to use the helper instead of inline zip logic.

## Test plan
- [x] Stage-dev warm build: pull finds caches, BitBake gets high sstate hit rate
- [x] Unchanged cache: push logs fingerprint skip for each type
- [ ] Missing zstd on runner: falls back to zip without failing the job hard