### PR TITLE
ci: STEP 4: skip git S3 archive; persist pnpm/electron/pip caches

### DIFF
--- a/.github/scripts/s3-bitbake-cache.sh
+++ b/.github/scripts/s3-bitbake-cache.sh
@@ -2,9 +2,14 @@
 # BitBake S3 cache for oe-core CI.
 #
 # Local trees (under <cachedir>/):
-#   downloads/   BitBake DL_DIR
-#   sstate/      BitBake SSTATE_DIR
-#   git/         BitBake GITDIR
+#   downloads/      BitBake DL_DIR
+#   sstate/         BitBake SSTATE_DIR
+#   git/            BitBake GITDIR
+#   pnpm/ electron/ pip/ pip-buildenv/  optional language tooling caches
+#
+# Override which trees are pulled/pushed with S3_BITBAKE_CACHE_TYPES
+# (comma-separated). CI skips the large git archive, e.g.:
+#   S3_BITBAKE_CACHE_TYPES=downloads,sstate,pnpm,electron,pip,pip-buildenv
 #
 # S3 objects (under <s3_prefix>/):
 #   <type>.tar.zst     archive of that tree (tar + zstd; preserves empty dirs)
@@ -15,6 +20,7 @@
 #         Missing objects are skipped (cold / partial cache is fine).
 #   push  Fingerprint each local tree. If it matches the remote .manifest, skip.
 #         Otherwise archive to .tar.zst, upload it, and write .manifest.
+#         Empty trees are not uploaded.
 #
 # Busting: change tree contents so the fingerprint no longer matches .manifest,
 # or delete the S3 objects. First merge of this format expects a cache miss;
@@ -24,10 +30,32 @@
 # script does not install packages.
 set -euo pipefail
 
-CACHE_TYPES=(downloads sstate git)
+DEFAULT_CACHE_TYPES=(downloads sstate git pnpm electron pip pip-buildenv)
+CACHE_TYPES=("${DEFAULT_CACHE_TYPES[@]}")
 
 log() {
   echo "$@"
+}
+
+resolve_cache_types() {
+  local raw="${S3_BITBAKE_CACHE_TYPES:-}"
+  local t
+  if [[ -z "$raw" ]]; then
+    CACHE_TYPES=("${DEFAULT_CACHE_TYPES[@]}")
+  else
+    CACHE_TYPES=()
+    # shellcheck disable=SC2086
+    for t in ${raw//,/ }; do
+      t="${t#"${t%%[![:space:]]*}"}"
+      t="${t%"${t##*[![:space:]]}"}"
+      [[ -n "$t" ]] && CACHE_TYPES+=("$t")
+    done
+  fi
+  if [[ ${#CACHE_TYPES[@]} -eq 0 ]]; then
+    log "ERROR: S3_BITBAKE_CACHE_TYPES resolved to an empty list" >&2
+    return 1
+  fi
+  log "Using cache types: ${CACHE_TYPES[*]}"
 }
 
 require_zstd() {
@@ -88,6 +116,7 @@ download_with_retries() {
 pull_all() {
   local s3_prefix="$1"
   local cachedir="$2"
+  resolve_cache_types
   require_zstd
   mkdir -p "$cachedir"
 
@@ -194,6 +223,7 @@ push_one() {
 push_all() {
   local s3_prefix="$1"
   local cachedir="$2"
+  resolve_cache_types
   require_zstd
 
   if [[ -d "$cachedir" ]]; then
@@ -211,6 +241,7 @@ push_all() {
 # Prints a single integer byte count on stdout.
 active_archive_size_bytes() {
   local s3_prefix="$1"
+  resolve_cache_types
   local cache_bucket="${s3_prefix#s3://}"
   cache_bucket="${cache_bucket%%/*}"
   local sizeInBytes=0
@@ -240,6 +271,10 @@ Usage:
   $0 pull <s3_prefix> <cachedir>
   $0 push <s3_prefix> <cachedir>
   $0 active-size-bytes <s3_prefix>
+
+Optional env:
+  S3_BITBAKE_CACHE_TYPES   Comma-separated subset of:
+                           downloads,sstate,git,pnpm,electron,pip,pip-buildenv
 EOF
 }
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,9 +22,10 @@ Builds are triggered:
 
 - There is a `LOCAL_CACHE` environment variable injected that points to a directory that will be present on subsequent builds on the same runner.
 - There is an `S3_CACHE_ARN` environment variable that is the ARN of an s3 bucket that can be used for caching.
-- BitBake cache trees (`downloads` / `sstate` / `git`) are stored on S3 as **`tar.zst`** plus a **`.manifest`** fingerprint. Helper: [`.github/scripts/s3-bitbake-cache.sh`](../scripts/s3-bitbake-cache.sh).
-- **Pull:** download each `.tar.zst` that exists (in parallel), then extract sequentially. Missing objects mean a cold/partial cache.
-- **Push:** fingerprint each tree (`path` + `size`, plus empty dirs). If it matches the remote `.manifest`, skip; otherwise archive with `zstd` and upload `.tar.zst` + `.manifest`.
+- BitBake cache trees are stored on S3 as **`tar.zst`** plus a **`.manifest`** fingerprint. Helper: [`.github/scripts/s3-bitbake-cache.sh`](../scripts/s3-bitbake-cache.sh).
+- Default types: `downloads`, `sstate`, `git`, `pnpm`, `electron`, `pip`, `pip-buildenv`. CI sets `S3_BITBAKE_CACHE_TYPES=downloads,sstate,pnpm,electron,pip,pip-buildenv` (skips the large `git` archive; monorepo/firmware use `externalsrc` bind mounts).
+- **Pull:** download each configured `.tar.zst` that exists (in parallel), then extract sequentially. Missing objects mean a cold/partial cache.
+- **Push:** fingerprint each tree (`path` + `size`, plus empty dirs). If it matches the remote `.manifest`, skip; otherwise archive with `zstd` and upload `.tar.zst` + `.manifest`. Empty trees are not uploaded.
 - **zstd** must already be on the ephemeral runner image (the script prints `zstd --version` or fails; it does not install packages).
 - First run after this format lands expects no hit; the following push seeds the new objects.
 - Build results go to an artifact bucket identified by `S3_ARTIFACT_ARN`.

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -433,6 +433,8 @@ jobs:
           cd ..
       - name: Apply unconditional CI config overrides
         run: |
+          cachedir=${LOCAL_CACHE:-./cache}
+          mkdir -p "${cachedir}"/{downloads,sstate,git,pnpm,electron,pip,pip-buildenv}
           cd oe-core
           echo "" >> ./conf/local.conf
           echo 'DL_DIR = "/volumes/cache/downloads"' >> ./conf/local.conf
@@ -473,6 +475,9 @@ jobs:
 
       - name: Pull S3 cache
         shell: bash
+        env:
+          # Skip the ~13GB git archive in CI; monorepo/firmware use externalsrc bind mounts.
+          S3_BITBAKE_CACHE_TYPES: downloads,sstate,pnpm,electron,pip,pip-buildenv
         run: |
           set -euo pipefail
           cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh
@@ -640,6 +645,8 @@ jobs:
       - name: Push S3 cache
         shell: bash
         continue-on-error: true
+        env:
+          S3_BITBAKE_CACHE_TYPES: downloads,sstate,pnpm,electron,pip,pip-buildenv
         run: |
           set -euo pipefail
           cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh


### PR DESCRIPTION
## Summary
- Add `S3_BITBAKE_CACHE_TYPES` allowlist to the BitBake S3 cache helper.
- CI sets `downloads,sstate,pnpm,electron,pip,pip-buildenv` (skips the ~13GB `git` archive).
- Create local cache dirs for the new types and document the allowlist.
- `active-size-bytes` respects the same allowlist (so leftover `git.tar.zst` does not inflate the 50GB gate).

## Notes
Retargeted onto `main` after the tar.zst PR (#349) merged. Rebased to resolve conflicts with the current helper (require-zstd / active-size-bytes).

## Test plan
- [ ] Pull logs `Using cache types: downloads sstate pnpm electron pip pip-buildenv`
- [ ] Pull wall time drops vs runs that fetched `git.tar.zst`
- [ ] After a build that populates pnpm/pip, push uploads new archives (or skips when unchanged)