### PR TITLE
meta-opentrons: include robot-server uds in audit-server service file

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
@@ -16,7 +16,7 @@ Environment=PYTHONPATH=/opt/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_persistence_directory=/var/lib/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_key_server_uds=/run/opentrons-key-server.sock
 Environment=OT_AUDIT_SERVER_auth_server_uds=/run/opentrons-auth-server.sock
-Environment=OT_AUDIT_SERVER_robot_server_url=http://localhost:31950
+Environment=OT_AUDIT_SERVER_robot_server_uds=/run/aiohttp.sock
 Restart=on-failure
 TimeoutStartSec=3min
 # We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.

--- a/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-audit-server/files/opentrons-audit-server.service
@@ -16,6 +16,7 @@ Environment=PYTHONPATH=/opt/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_persistence_directory=/var/lib/opentrons-audit-server
 Environment=OT_AUDIT_SERVER_key_server_uds=/run/opentrons-key-server.sock
 Environment=OT_AUDIT_SERVER_auth_server_uds=/run/opentrons-auth-server.sock
+Environment=OT_AUDIT_SERVER_robot_server_url=http://localhost:31950
 Restart=on-failure
 TimeoutStartSec=3min
 # We're using PrivateTmp for its feature of automatically cleaning up if the service crashes.


### PR DESCRIPTION
Addresses part of EXEC-2779.

For the audit-server log period download, we need to get the robot's name and serial number to write to a robot identity file. To do so, we need to ping the robot-server's `/health` endpoint to get this information. Now on audit server boot we will look for one of `OT_AUDIT_SERVER_robot_server_url` or `OT_AUDIT_SERVER_robot_server_uds` to establish connection with the robot server. This PR adds the latter, allowing us to talk with the robot-server when the audit server is running on a Flex.