### PR TITLE
fix(ci): unblock image build after tar.zst cache migration

### DIFF
--- a/.github/scripts/s3-bitbake-cache.sh
+++ b/.github/scripts/s3-bitbake-cache.sh
@@ -8,8 +8,9 @@
 #   pnpm/ electron/ pip/ pip-buildenv/  optional language tooling caches
 #
 # Override which trees are pulled/pushed with S3_BITBAKE_CACHE_TYPES
-# (comma-separated). CI skips the large git archive, e.g.:
+# (comma-separated). CI may omit large trees, e.g.:
 #   S3_BITBAKE_CACHE_TYPES=downloads,sstate,pnpm,electron,pip,pip-buildenv
+# During tar.zst warm-up, CI includes git to reduce live Toradex fetches.
 #
 # S3 objects (under <s3_prefix>/):
 #   <type>.tar.zst     archive of that tree (tar + zstd; preserves empty dirs)
@@ -55,7 +56,8 @@ resolve_cache_types() {
     log "ERROR: S3_BITBAKE_CACHE_TYPES resolved to an empty list" >&2
     return 1
   fi
-  log "Using cache types: ${CACHE_TYPES[*]}"
+  # stderr so command-substitution callers (active-size-bytes) get only the integer.
+  log "Using cache types: ${CACHE_TYPES[*]}" >&2
 }
 
 require_zstd() {
@@ -249,11 +251,14 @@ active_archive_size_bytes() {
 
   for cachetype in "${CACHE_TYPES[@]}"; do
     key="${cachetype}.tar.zst"
-    len=$(aws s3api head-object \
+    if ! len=$(aws s3api head-object \
       --bucket "${cache_bucket}" \
       --key "${key}" \
       --query ContentLength \
-      --output text 2>/dev/null || echo 0)
+      --output text 2>/dev/null); then
+      log "Cache object s3://${cache_bucket}/${key}: missing" >&2
+      continue
+    fi
     if [[ "${len}" =~ ^[0-9]+$ ]]; then
       sizeInBytes=$((sizeInBytes + len))
       log "Cache object s3://${cache_bucket}/${key}: ${len} bytes" >&2

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ Builds are triggered:
 - There is a `LOCAL_CACHE` environment variable injected that points to a directory that will be present on subsequent builds on the same runner.
 - There is an `S3_CACHE_ARN` environment variable that is the ARN of an s3 bucket that can be used for caching.
 - BitBake cache trees are stored on S3 as **`tar.zst`** plus a **`.manifest`** fingerprint. Helper: [`.github/scripts/s3-bitbake-cache.sh`](../scripts/s3-bitbake-cache.sh).
-- Default types: `downloads`, `sstate`, `git`, `pnpm`, `electron`, `pip`, `pip-buildenv`. CI sets `S3_BITBAKE_CACHE_TYPES=downloads,sstate,pnpm,electron,pip,pip-buildenv` (skips the large `git` archive; monorepo/firmware use `externalsrc` bind mounts).
+- Default types: `downloads`, `sstate`, `git`, `pnpm`, `electron`, `pip`, `pip-buildenv`. CI currently sets `S3_BITBAKE_CACHE_TYPES=downloads,sstate,git,pnpm,electron,pip,pip-buildenv` (includes `git` while warming the tar.zst cache so BitBake is less exposed to Toradex).
 - **Pull:** download each configured `.tar.zst` that exists (in parallel), then extract sequentially. Missing objects mean a cold/partial cache.
 - **Push:** fingerprint each tree (`path` + `size`, plus empty dirs). If it matches the remote `.manifest`, skip; otherwise archive with `zstd` and upload `.tar.zst` + `.manifest`. Empty trees are not uploaded.
 - **zstd** must already be on the ephemeral runner image (the script prints `zstd --version` or fails; it does not install packages).

--- a/.github/workflows/build-ot3-actions.yml
+++ b/.github/workflows/build-ot3-actions.yml
@@ -319,10 +319,28 @@ jobs:
             exit 1
           fi
       - name: Sync oe-core submodules
+        shell: bash
         run: |
+          set -euo pipefail
           chown -R "$(whoami)" oe-core opentrons ot3-firmware
           cd oe-core
-          ./update.sh
+          # Toradex git hosts occasionally return 502; retry before failing the job.
+          max_attempts=5
+          attempt=1
+          while true; do
+            echo "Syncing oe-core submodules (attempt ${attempt}/${max_attempts})"
+            if ./update.sh; then
+              break
+            fi
+            if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+              echo "Submodule sync failed after ${max_attempts} attempts" >&2
+              exit 1
+            fi
+            sleep_secs=$((attempt * 30))
+            echo "Submodule sync failed; retrying in ${sleep_secs}s..."
+            sleep "${sleep_secs}"
+            attempt=$((attempt + 1))
+          done
           cd ..
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
@@ -363,11 +381,16 @@ jobs:
           else
             ecr_repo="${{ vars.OT3_OE_DOCKER_ECR_REPOSITORY_PROD }}"
           fi
-          if [[ -z "$ecr_repo" ]]; then
-            echo "OT3_OE_DOCKER_ECR_REPOSITORY_* not set for ${{ matrix.build_env }}; Docker build will run without ECR layer cache."
-          else
-            echo "Using ECR repository ${ecr_repo} for BuildKit layer cache"
-          fi
+          # Placeholder / unset vars must not enable BuildKit registry cache.
+          case "$(echo "${ecr_repo}" | tr '[:upper:]' '[:lower:]')" in
+            ""|na|n/a|none|null)
+              ecr_repo=""
+              echo "OT3_OE_DOCKER_ECR_REPOSITORY_* not set for ${{ matrix.build_env }}; Docker build will run without ECR layer cache."
+              ;;
+            *)
+              echo "Using ECR repository ${ecr_repo} for BuildKit layer cache"
+              ;;
+          esac
           echo "ECR_REPOSITORY=${ecr_repo}" >> "$GITHUB_ENV"
       - name: Login to Amazon ECR
         if: ${{ env.ECR_REPOSITORY != '' }}
@@ -405,30 +428,41 @@ jobs:
             --tag "ot3-image:latest"
           )
 
-          if [[ -n "${ECR_REPOSITORY:-}" ]]; then
-            repo_name="${ECR_REPOSITORY#*/}"
-            aws ecr describe-repositories --repository-names "$repo_name" >/dev/null 2>&1 || \
-              aws ecr create-repository \
-                --repository-name "$repo_name" \
-                --image-tag-mutability MUTABLE \
-                --encryption-configuration encryptionType=AES256
-
-            cache_ref="${ECR_REPOSITORY}:buildcache-${dockerfile_cache_key}"
-            echo "Building with BuildKit ECR layer cache: ${cache_ref}"
-
-            docker buildx rm oe-ci-builder >/dev/null 2>&1 || true
-            docker buildx create --name oe-ci-builder --driver docker-container --use --bootstrap
-
-            docker buildx build \
-              "${build_args[@]}" \
-              --cache-from "type=registry,ref=${cache_ref}" \
-              --cache-to "type=registry,ref=${cache_ref},mode=max" \
-              --load \
-              "$tmp_dir"
-          else
+          build_without_ecr_cache() {
             echo "Building without ECR layer cache"
             # Must match host runner uid/gid so bind-mounted oe-core/cache are writable (see Dockerfile).
             docker build "${build_args[@]}" "$tmp_dir"
+          }
+
+          if [[ -n "${ECR_REPOSITORY:-}" ]]; then
+            if ! (
+              set -euo pipefail
+              repo_name="${ECR_REPOSITORY#*/}"
+              aws ecr describe-repositories --repository-names "$repo_name" >/dev/null 2>&1 || \
+                aws ecr create-repository \
+                  --repository-name "$repo_name" \
+                  --image-tag-mutability MUTABLE \
+                  --encryption-configuration encryptionType=AES256
+
+              cache_ref="${ECR_REPOSITORY}:buildcache-${dockerfile_cache_key}"
+              echo "Building with BuildKit ECR layer cache: ${cache_ref}"
+
+              docker buildx rm oe-ci-builder >/dev/null 2>&1 || true
+              docker buildx create --name oe-ci-builder --driver docker-container --use --bootstrap
+
+              docker buildx build \
+                "${build_args[@]}" \
+                --cache-from "type=registry,ref=${cache_ref}" \
+                --cache-to "type=registry,ref=${cache_ref},mode=max" \
+                --load \
+                "$tmp_dir"
+            ); then
+              echo "BuildKit ECR cache path failed; falling back to plain docker build" >&2
+              docker buildx rm oe-ci-builder >/dev/null 2>&1 || true
+              build_without_ecr_cache
+            fi
+          else
+            build_without_ecr_cache
           fi
           cd ..
       - name: Apply unconditional CI config overrides
@@ -477,8 +511,8 @@ jobs:
       - name: Pull S3 cache
         shell: bash
         env:
-          # Skip the ~13GB git archive in CI; monorepo/firmware use externalsrc bind mounts.
-          S3_BITBAKE_CACHE_TYPES: downloads,sstate,pnpm,electron,pip,pip-buildenv
+          # Include git during tar.zst cache warm-up so cold BitBake is less exposed to Toradex.
+          S3_BITBAKE_CACHE_TYPES: downloads,sstate,git,pnpm,electron,pip,pip-buildenv
         run: |
           set -euo pipefail
           cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh
@@ -647,7 +681,8 @@ jobs:
         shell: bash
         continue-on-error: true
         env:
-          S3_BITBAKE_CACHE_TYPES: downloads,sstate,pnpm,electron,pip,pip-buildenv
+          # Keep in sync with Pull S3 cache while warming the tar.zst git archive.
+          S3_BITBAKE_CACHE_TYPES: downloads,sstate,git,pnpm,electron,pip,pip-buildenv
         run: |
           set -euo pipefail
           cache_script=./oe-core-for-workflow/.github/scripts/s3-bitbake-cache.sh


### PR DESCRIPTION
## Overview

Unblock main Flex image builds after the recent tar.zst / ECR cache PRs without rolling those changes back.

**Validated:** untagged image build on this branch succeeded: https://github.com/Opentrons/oe-core/actions/runs/30000863098

## Changelog

- Keep `active-size-bytes` stdout as a bare integer (`resolve_cache_types` logs to stderr) so Pull S3 cache arithmetic no longer fails
- Treat placeholder ECR repo vars (`na`, `n/a`, `none`, `null`) as unset; fall back to plain `docker build` if BuildKit+ECR fails
- Retry Toradex submodule sync (`./update.sh`) with backoff
- Temporarily include `git` in `S3_BITBAKE_CACHE_TYPES` while warming tar.zst archives

## Test plan

- [x] Dispatch untagged image build on this branch (`oe-core-ref` = this branch, monorepo `-` / edge): [run 30000863098](https://github.com/Opentrons/oe-core/actions/runs/30000863098)
- [x] Confirm Pull S3 cache prints `Active tar.zst cache total: 0GB (0 bytes)` without exit 1
- [x] Confirm Docker uses a real ECR repo or falls back without failing
- [x] Confirm submodule sync succeeds (or shows retries then succeeds)
- [x] Toradex submodule retry worked (attempts 1–3 failed with 502s; attempt 4/5 succeeded in [run 30000863098](https://github.com/Opentrons/oe-core/actions/runs/30000863098))
- [x] After green, retry tagged `v9.1.2-alpha.1` build from main (post-merge)