### PR TITLE
fix(networkmanager): recover mlan0 when NM is connected without carrier

### DIFF
--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/mlan0-desync-check.service
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/mlan0-desync-check.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Opentrons mlan0 Wi-Fi desync check
+Documentation=file:///usr/sbin/mlan0-desync-check.sh
+After=NetworkManager.service
+Wants=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/mlan0-desync-check.sh
+TimeoutStartSec=90

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/mlan0-desync-check.sh
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/mlan0-desync-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# Soft-reconnect mlan0 when NetworkManager reports connected but the radio has
+# no carrier (field desync). Called by mlan0-desync-check.timer.
+
+set -eu
+
+IFACE="mlan0"
+
+nmcli -t -f DEVICE,STATE device 2>/dev/null | grep -q "^${IFACE}:connected$" || exit 0
+
+carrier=$(cat "/sys/class/net/${IFACE}/carrier" 2>/dev/null || echo 0)
+[ "$carrier" = "1" ] && exit 0
+
+conn=$(nmcli -t -f GENERAL.CONNECTION device show "$IFACE" 2>/dev/null | head -n1)
+conn=${conn#GENERAL.CONNECTION:}
+[ -n "$conn" ] && [ "$conn" != "--" ] || exit 0
+
+echo "Detected ${IFACE} desync, reconnecting $conn"
+nmcli -w 30 connection down "$conn" || true
+sleep 2
+nmcli -w 60 connection up "$conn" || true

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/files/mlan0-desync-check.timer
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/files/mlan0-desync-check.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Periodically run mlan0 Wi-Fi desync check
+After=NetworkManager.service
+
+[Timer]
+# First run after boot once Wi-Fi has had time to associate.
+OnBootSec=90s
+# Catch silent desync without relying on NetworkManager dispatcher events.
+OnUnitActiveSec=60s
+AccuracySec=15s
+Persistent=true
+Unit=mlan0-desync-check.service
+
+[Install]
+WantedBy=timers.target

--- a/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-opentrons/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -9,11 +9,17 @@ SRC_URI += "file://system-connections-location.conf \
             file://wired-end0.nmconnection \
             file://opentrons-init-systemconnections.service\
             file://dispatch-bounce-mlan0.sh \
+            file://mlan0-desync-check.sh \
+            file://mlan0-desync-check.service \
+            file://mlan0-desync-check.timer \
 "
 
 FILES:${PN} += "/etc/NetworkManager/conf.d/system-connections-location.conf \
                 /etc/NetworkManager/conf.d/disable-uap0.conf \
                 ${systemd_system_unitdir}/opentrons-init-systemconnections.service \
+                ${systemd_system_unitdir}/mlan0-desync-check.service \
+                ${systemd_system_unitdir}/mlan0-desync-check.timer \
+                ${sbindir}/mlan0-desync-check.sh \
                 /usr/share/default-connections/wired-linklocal.nmconnection \
                 /usr/share/default-connections/wired.nmconnection \
                 /usr/share/default-connections/wired-end0-linklocal.nmconnection \
@@ -26,18 +32,24 @@ do_install:append() {
 	install -d ${D}/etc/NetworkManager/conf.d
 	install -m 644 ${WORKDIR}/system-connections-location.conf ${D}/etc/NetworkManager/conf.d/
 	install -m 644 ${WORKDIR}/disable-uap0.conf ${D}/etc/NetworkManager/conf.d/
-    install -d ${D}/usr/share/default-connections
-    install -m 600 ${WORKDIR}/wired-linklocal.nmconnection ${D}/usr/share/default-connections/wired-linklocal.nmconnection
-    install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/default-connections/wired.nmconnection
-    install -m 600 ${WORKDIR}/wired-end0-linklocal.nmconnection ${D}/usr/share/default-connections/wired-end0-linklocal.nmconnection
-    install -m 600 ${WORKDIR}/wired-end0.nmconnection ${D}/usr/share/default-connections/wired-end0.nmconnection
-    install -d ${D}${systemd_system_unitdir}
-    install -m 0644 ${WORKDIR}/opentrons-init-systemconnections.service ${D}${systemd_system_unitdir}/opentrons-init-systemconnections.service
-    install -d ${D}${systemd_system_unitdir}/NetworkManager.service.wants
-    ln -s ../opentrons-init-systemconnections.service ${D}${systemd_system_unitdir}/NetworkManager.service.wants/opentrons-init-systemconnections.service
-    install -d ${D}/etc/NetworkManager/dispatcher.d
-    install -m 744 ${WORKDIR}/dispatch-bounce-mlan0.sh ${D}/etc/NetworkManager/dispatcher.d/bounce-mlan0.sh
+	install -d ${D}/usr/share/default-connections
+	install -m 600 ${WORKDIR}/wired-linklocal.nmconnection ${D}/usr/share/default-connections/wired-linklocal.nmconnection
+	install -m 600 ${WORKDIR}/wired.nmconnection ${D}/usr/share/default-connections/wired.nmconnection
+	install -m 600 ${WORKDIR}/wired-end0-linklocal.nmconnection ${D}/usr/share/default-connections/wired-end0-linklocal.nmconnection
+	install -m 600 ${WORKDIR}/wired-end0.nmconnection ${D}/usr/share/default-connections/wired-end0.nmconnection
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/opentrons-init-systemconnections.service ${D}${systemd_system_unitdir}/opentrons-init-systemconnections.service
+	install -d ${D}${systemd_system_unitdir}/NetworkManager.service.wants
+	ln -s ../opentrons-init-systemconnections.service ${D}${systemd_system_unitdir}/NetworkManager.service.wants/opentrons-init-systemconnections.service
+	install -d ${D}/etc/NetworkManager/dispatcher.d
+	install -m 0755 ${WORKDIR}/dispatch-bounce-mlan0.sh ${D}/etc/NetworkManager/dispatcher.d/bounce-mlan0.sh
+	install -d ${D}${sbindir}
+	install -m 0755 ${WORKDIR}/mlan0-desync-check.sh ${D}${sbindir}/mlan0-desync-check.sh
+	install -m 0644 ${WORKDIR}/mlan0-desync-check.service ${D}${systemd_system_unitdir}/mlan0-desync-check.service
+	install -m 0644 ${WORKDIR}/mlan0-desync-check.timer ${D}${systemd_system_unitdir}/mlan0-desync-check.timer
 }
 
 SYSTEMD_AUTO_ENABLE = "enable"
-SYSTEMD_SERVICE:${PN}:append = " opentrons-init-systemconnections.service"
+SYSTEMD_SERVICE:${PN}:append = " opentrons-init-systemconnections.service \
+                                 mlan0-desync-check.timer \
+"


### PR DESCRIPTION
## Summary

Sometimes Flex Wi-Fi gets stuck where NetworkManager still reports `mlan0` **connected** (with an IP) but the radio has **no carrier** and is not associated. The UI/API say Wi-Fi is up, but the Wi-Fi IP is unreachable. Ethernet can still work.

This usually shows up after the link has been up for a while (roam/rekey/driver hiccup). `wpa_supplicant` may log `Reject scan trigger since one is already pending`, and NetworkManager never emits a useful `down` event, so the existing crash-only `bounce-mlan0` path never runs.

Closes: [RQA-5751](https://opentrons.atlassian.net/browse/RQA-5751)

### Changelog

- Add a `check` mode: if NM says `mlan0:connected` and carrier is 0, soft-reconnect with `nmcli connection down/up`.
- Run that check on a oneshot timer every 60s (`bounce-mlan0-check.timer`).

## Test plan
- [ ] Build/install image with this change
- [ ] Confirm timer is active: `systemctl status bounce-mlan0-check.timer`
- [ ] Healthy Wi-Fi: check is a no-op (`bounce-mlan0.sh check` / timer logs quiet)
- [ ] On a desynced robot (NM connected + `NO-CARRIER`): timer or manual `bounce-mlan0.sh check` restores association and Wi-Fi IP reachability
- [ ] Ethernet stays up during soft reconnect

[RQA-5751]: https://opentrons.atlassian.net/browse/RQA-5751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ