### PR TITLE
mergeback release to main (productionV2 + smartscan)

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/95-opentrons-udev.rules
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/95-opentrons-udev.rules
@@ -25,4 +25,7 @@ KERNEL=="video[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="9230", ATTRS{idVend
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ef40", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_vacuummodule%n"
 
 # barcode scanner
+#RTSCAN
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="1d06", ATTRS{idVendor}=="1eab", SYMLINK+="ot_module_barcodescanner%n"
+#SMARTSCANNER
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="3003", ATTRS{idVendor}=="ac90", SYMLINK+="ot_module_barcodescanner%n"

--- a/scripts/update_releases_file.py
+++ b/scripts/update_releases_file.py
@@ -28,16 +28,14 @@ def main(args):
             releases = json.load(fh)
 
     # Update the releases dict with the latest version
-    releases.get("productionV2", {}).update(
-        {
-            f"{version}": {
-                "fullImage": f"{base_url}/ot3-fullimage.tar",
-                "system": f"{base_url}/ot3-system.zip",
-                "version": f"{base_url}/VERSION.json",
-                "releaseNotes": f"{base_url}/release-notes.md",
-            }
-        }
-    )
+    if 'productionV2' not in releases:
+        releases['productionV2'] = {}
+    releases['productionV2'][f'{version}'] = {
+        "fullImage": f"{base_url}/ot3-fullimage.tar",
+        "system": f"{base_url}/ot3-system.zip",
+        "version": f"{base_url}/VERSION.json",
+        "releaseNotes": f"{base_url}/release-notes.md",
+    }
 
     # Save the new releases.json file
     with open(releases_file, "w") as fh:

--- a/scripts/update_releases_file.py
+++ b/scripts/update_releases_file.py
@@ -1,4 +1,5 @@
 """A script to help update the releases.json file."""
+
 import os
 import sys
 import json
@@ -20,14 +21,14 @@ def main(args):
         exit(1)
 
     # Get the releases from the releases file
-    releases = {"production": {}}
+    releases = {"productionV2": {}}
     if os.path.exists(releases_file):
         print(f"reading releases file - {releases_file}")
         with open(releases_file, "r") as fh:
             releases = json.load(fh)
 
     # Update the releases dict with the latest version
-    releases.get("production", {}).update(
+    releases.get("productionV2", {}).update(
         {
             f"{version}": {
                 "fullImage": f"{base_url}/ot3-fullimage.tar",
@@ -42,7 +43,7 @@ def main(args):
     with open(releases_file, "w") as fh:
         json.dump(releases, fh)
     print(
-        f"Updated {releases_file} with - {version}: {releases['production'][version]}"
+        f"Updated {releases_file} with - {version}: {releases['productionV2'][version]}"
     )
 
 


### PR DESCRIPTION
## Summary
- Merge `origin/release` into `main` (not cherry-picks), preserving original commit SHAs.
- `release` and `chore_release-9.1.1` are currently the same tip (`6868e408`).
- Commits brought in:
  - `8f64064a` [#334](https://github.com/Opentrons/oe-core/pull/334) smartscan udev rule
  - `a5a0c840` [#336](https://github.com/Opentrons/oe-core/pull/336) push builds to `productionV2`
  - `6868e408` [#338](https://github.com/Opentrons/oe-core/pull/338) fix `update_releases_file`

## Why
9.1.1+ clients read `productionV2`. That publisher change only lived on the release line, so `ot3@*` tag builds based on `main` kept writing to `production` (`4.0.0-alpha.5` onward, including `alpha.8`).

## Merge note
Do **not** squash or rebase-merge. Use a normal merge so `a5a0c840` / `6868e408` / `8f64064a` remain reachable from `main` unchanged.

## Follow-up (not in this PR)
- Manually move `4.0.0-alpha.5`–`alpha.8` (and any 4.1 builds that should be on the new channel) from `production` → `productionV2` in S3 `ot3-oe/releases.json`.

## Test plan
- [ ] After merge, `git merge-base --is-ancestor a5a0c840 origin/main` is true
- [ ] `scripts/update_releases_file.py` on `main` writes to `productionV2`
- [ ] Next tagged Flex build appears under `productionV2` in https://ot3-development.builds.opentrons.com/ot3-oe/releases.json