### PR TITLE
fix(build): disable EXTERNALSRC_SYMLINKS for shared monorepo tree

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -268,6 +268,11 @@ RM_WORK_EXCLUDE += "opentrons-ot3-image"
 # Add Toradex source mirror
 INHERIT += "toradex-mirrors insane"
 
+# The opentrons recipes all use the monorepo checkout as EXTERNALSRC, so the
+# per-recipe oe-workdir/oe-logs symlinks would all target the same paths and
+# race when their do_configure tasks overlap.
+EXTERNALSRC_SYMLINKS = ""
+
 # Use this distro
 DISTRO = "opentrons"
 


### PR DESCRIPTION
## Summary
- Set `EXTERNALSRC_SYMLINKS = ""` in `conf/local.conf` so `externalsrc` no longer creates per-recipe `oe-workdir` / `oe-logs` symlinks in the shared monorepo checkout.
- Those defaults race when multiple monorepo recipes run `do_configure` in parallel (`FileExistsError` on `oe-workdir`).

## Test plan
- [x] Rebuild an image (or at least the monorepo recipes) with normal `BB_NUMBER_THREADS` and confirm `opentrons-update-server` / `opentrons-robot-server` `do_configure` succeed concurrently
- [ ] Confirm no tooling depends on `/volumes/opentrons/oe-workdir` or `oe-logs` existing


Made with [Cursor](https://cursor.com)