### PR TITLE
opentrons-robot-server: alter hwapi startup check

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
@@ -8,7 +8,7 @@ Before=opentrons-robot-server.service
 
 [Service]
 # Ensure the subprocess is enabled to continue
-ExecCondition=ExecCondition=/bin/sh -c 'test ! -r /data/feature_flags.json || /usr/bin/jq -ne "try (input.disableHardwareSubprocess != true) catch true" /data/feature_flags.json'
+ExecCondition=/bin/sh -c 'test ! -r /data/feature_flags.json || /usr/bin/jq -ne "try (input.disableHardwareSubprocess != true) catch true" /data/feature_flags.json'
 
 # If ExecConditions were met proceed to start the Hardware API subprocess
 Type=notify

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
@@ -8,7 +8,7 @@ Before=opentrons-robot-server.service
 
 [Service]
 # Ensure the subprocess is enabled to continue
-ExecCondition=/usr/bin/jq -r -e '.enableHardwareSubprocess?' /data/feature_flags.json
+ExecCondition=ExecCondition=/bin/sh -c 'test ! -r /data/feature_flags.json || /usr/bin/jq -ne "try (input.disableHardwareSubprocess != true) catch true" /data/feature_flags.json'
 
 # If ExecConditions were met proceed to start the Hardware API subprocess
 Type=notify


### PR DESCRIPTION
This now checks for the presence and truthiness of a new feature flag that disables hardware subprocesses. This is annoying compared to swapping the default value of the old feature flag, but since migrations happen in the robot server and the robot server doesn't start until after the hardware server, we can't rely on migrations here. This way, the process will start unless the migration has already run and a user has explicitly flipped the flag. the new flag is `disableHardwareSubprocess`.

there's a bunch of extra shell stuff in there so that the condition is true if the feature_flags file doesn't exist (like on first boot) or it's mangled.