### PR TITLE
chore(docker): pin uv to 0.12.1 for Flex app exports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 # bookworm is the latest tested debian version for scarthgap per
 # https://docs.yoctoproject.org/5.0.12/ref-manual/system-requirements.html
 FROM python:3.12-bookworm
-COPY --from=ghcr.io/astral-sh/uv:0.9.17 /uv /uvx /bin/
+# Keep in sync with required-version in the opentrons monorepo (uv.toml and each
+# project's [tool.uv]); do_configure runs `uv export --frozen` inside that tree.
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /uvx /bin/
 # Set timezone:
 RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone
 


### PR DESCRIPTION
## Summary
- Bump the Flex build image from `ghcr.io/astral-sh/uv:0.9.17` to `0.12.1`
- Aligns oe-core's `uv export --frozen` (in `opentrons_app_bundle.bbclass` `do_configure`) with the opentrons monorepo `required-version` pin

## Why
The monorepo is pinning uv to `==0.12.1` via root `uv.toml` and each project's `[tool.uv] required-version`. Flex builds run `uv export` inside those project directories, so oe-core must ship the same uv version first — otherwise monorepo merges that add `required-version` will fail Flex image builds.

## Test plan
- [x] Confirm CI rebuilds the Docker image (cache key includes Dockerfile sha)
- [x] Confirm Flex app recipes still pass `do_configure` / `uv export --group robot --frozen`
- [ ] Land this before merging the monorepo `required-version` changes