### PR TITLE
layers/meta-opentrons: remote access checks

### DIFF
--- a/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
@@ -24,4 +24,9 @@ do_install:append() {
    install -m 0644 ${WORKDIR}/require-remote-access.conf "${D}${systemd_system_unitdir}/dropbear\@.service.d/require-remote-access.conf"
 }
 
-FILES:${PN} += " /root /root/.ssh ${systemd_system_unitdir}/dropbear@.service.d/require-remote-access.conf"
+FILES:${PN} += " \
+   /root \
+   /root/.ssh \
+   ${systemd_system_unitdir}/dropbear\@.service.d \
+   ${systemd_system_unitdir}/dropbear\@.service.d/require-remote-access.conf \
+   "

--- a/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
@@ -20,8 +20,8 @@ do_install:append() {
    fi
 
    # install remote access config
-   install -d -m 0644 "${D}${systemd_system_unitdir}/dropbear\@.service.d"
-   install -m 0644 ${WORKDIR}/require-remote-access.conf "${D}${systemd_system_unitdir}/dropbear\@.service.d/require-remote-access.conf"
+   install -d -m 0644 "${D}${systemd_system_unitdir}/dropbear@.service.d"
+   install -m 0644 ${WORKDIR}/require-remote-access.conf "${D}${systemd_system_unitdir}/dropbear@.service.d/require-remote-access.conf"
 }
 
 FILES:${PN} += " \

--- a/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://opentrons-dropbear.default"
+SRC_URI += "file://opentrons-dropbear.default file://require-remote-access.conf"
 
 
 do_install:append() {
@@ -18,6 +18,10 @@ do_install:append() {
       bbnote "Installing custom dropbear config for release build."
       install -m 0644 ${WORKDIR}/opentrons-dropbear.default ${D}${sysconfdir}/default/dropbear
    fi
+
+   # install remote access config
+   install -d -m 0644 "${D}${systemd_system_unitdir}/dropbear\@.service.d"
+   install -m 0644 ${WORKDIR}/require-remote-access.conf "${D}${systemd_system_unitdir}/dropbear\@.service.d/require-remote-access.conf"
 }
 
-FILES:${PN} += " /root /root/.ssh "
+FILES:${PN} += " /root /root/.ssh ${systemd_system_unitdir}/dropbear@.service.d/require-remote-access.conf"

--- a/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
+++ b/layers/meta-opentrons/recipes-core/dropbear/dropbear_%.bbappend
@@ -27,6 +27,6 @@ do_install:append() {
 FILES:${PN} += " \
    /root \
    /root/.ssh \
-   ${systemd_system_unitdir}/dropbear\@.service.d \
-   ${systemd_system_unitdir}/dropbear\@.service.d/require-remote-access.conf \
+   ${systemd_system_unitdir}/dropbear@.service.d \
+   ${systemd_system_unitdir}/dropbear@.service.d/require-remote-access.conf \
    "

--- a/layers/meta-opentrons/recipes-core/dropbear/files/require-remote-access.conf
+++ b/layers/meta-opentrons/recipes-core/dropbear/files/require-remote-access.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=opentrons-remote-access-allowed.service
+After=opentrons-remote-access-allowed.service

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/check_remote_access_allowed
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/check_remote_access_allowed
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+import asyncio
+import sys
+import os
+import traceback
+import json
+
+import logging
+
+logging.basicConfig(level=logging.ERROR)
+
+
+async def _do_check():
+    import aiohttp
+
+    uds = os.environ["CHECK_REMOTE_ACCESS_auth_server_uds"]
+    connector = aiohttp.UnixConnector(path=uds)
+    async with aiohttp.ClientSession(
+        connector=connector,
+        base_url="http://localhost",
+    ) as session:
+        async with session.get("auth/settings/accessControlEnabled") as response:
+            response.raise_for_status()
+            response_bytes = await response.read()
+
+    parsed_response = json.loads(response_bytes)
+    if parsed_response["data"]["accessControlEnabled"] is False:
+        print("Allowing remote access: CRS is disabled")
+        return 0
+    path = os.environ["CHECK_REMOTE_ACCESS_override_file"]
+    if os.path.exists(path):
+        print("Allowing remote access: override file exists")
+        return 0
+    print("Disallowing remote access: CRS is enabled and no override exists")
+    return 1
+
+
+async def check():
+    try:
+        return await _do_check()
+    except Exception:
+        print("Disallowing remote access: error in check process")
+        traceback.print_exc()
+        return 2
+
+
+sys.exit(asyncio.run(check()))

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/check_remote_access_allowed
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/check_remote_access_allowed
@@ -14,7 +14,7 @@ if "/opt/opentrons-auth-server" not in sys.path:
     sys.path.append("/opt/opentrons-auth-server")
 
 
-async def _do_check():
+async def _http_check() -> bool:
     import aiohttp
 
     connector = aiohttp.UnixConnector(path="/run/opentrons-auth-server.sock")
@@ -25,25 +25,82 @@ async def _do_check():
         async with session.get("auth/settings/accessControlEnabled") as response:
             response.raise_for_status()
             response_bytes = await response.read()
-
     parsed_response = json.loads(response_bytes)
-    if parsed_response["data"]["accessControlEnabled"] is False:
-        print("Allowing remote access: CRS is disabled")
-        return 0
+    return parsed_response["data"]["accessControlEnabled"]
+
+
+async def _do_check(timeout: int | None):
     if os.path.exists("/etc/opentrons-allow-remote-access"):
         print("Allowing remote access: override file exists")
+        return 0
+
+    tries = 0
+    while True:
+        try:
+            enabled = await _http_check()
+            break
+        except Exception:
+            if timeout is None or tries < timeout:
+                tries += 1
+                await asyncio.sleep(1)
+            else:
+                print(
+                    f"Disallowing remote access: no override exists and the auth-server cannot be reached after {tries} seconds"
+                )
+                return 1
+
+    if enabled is False:
+        print("Allowing remote access: CRS is disabled")
         return 0
     print("Disallowing remote access: CRS is enabled and no override exists")
     return 1
 
 
-async def check():
+async def check(timeout: int | None):
     try:
-        return await _do_check()
+        return await _do_check(timeout)
     except Exception:
         print("Disallowing remote access: error in check process")
         traceback.print_exc()
         return 2
 
 
-sys.exit(asyncio.run(check()))
+def timeout_or(argv: list[str]) -> int | None:
+    if len(sys.argv) < 2:
+        return None
+    if ("-h", "--help") in sys.argv[1]:
+        print(f"{sys.argv[0]} [-h | --help] [TIMEOUT]")
+        print(f"-h | --help: print this")
+        print(
+            f"TIMEOUT: a whole number greater than 0 in seconds to wait for auth server"
+        )
+        print()
+        print(
+            "Checks whether remote access is allowed. Exits with 0 if allowed, not-0 otherwise."
+        )
+        print(
+            "Access is allowed if either /etc/opentrons-allow-remote-access exists or if "
+        )
+        print(
+            "opentrons-auth-server is active and GET /auth/settings/accessControlEnabled indicates "
+        )
+        print("that CRS is disabled (i.e., has data.accessControlEnabled != true). ")
+        print(
+            "Will retry this HTTP call once per second for up to TIMEOUT seconds if it does not "
+        )
+        print("have a status of 200.")
+        sys.exit(-1)
+
+    possible_val = sys.argv[1]
+    try:
+        val = int(sys.argv[1])
+    except ValueError:
+        sys.stderr.write(f"Bad timeout: {sys.argv[1]} must be an int\n")
+        return None
+    if val < 1:
+        sys.stderr.write(f"Bad timeout: {sys.argv[1]} must be greater than 0\n")
+        return None
+    return val
+
+
+sys.exit(asyncio.run(check(timeout_or(sys.argv))))

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/check_remote_access_allowed
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/check_remote_access_allowed
@@ -10,12 +10,14 @@ import logging
 
 logging.basicConfig(level=logging.ERROR)
 
+if "/opt/opentrons-auth-server" not in sys.path:
+    sys.path.append("/opt/opentrons-auth-server")
+
 
 async def _do_check():
     import aiohttp
 
-    uds = os.environ["CHECK_REMOTE_ACCESS_auth_server_uds"]
-    connector = aiohttp.UnixConnector(path=uds)
+    connector = aiohttp.UnixConnector(path="/run/opentrons-auth-server.sock")
     async with aiohttp.ClientSession(
         connector=connector,
         base_url="http://localhost",
@@ -28,8 +30,7 @@ async def _do_check():
     if parsed_response["data"]["accessControlEnabled"] is False:
         print("Allowing remote access: CRS is disabled")
         return 0
-    path = os.environ["CHECK_REMOTE_ACCESS_override_file"]
-    if os.path.exists(path):
+    if os.path.exists("/etc/opentrons-allow-remote-access"):
         print("Allowing remote access: override file exists")
         return 0
     print("Disallowing remote access: CRS is enabled and no override exists")

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
@@ -6,7 +6,7 @@ After=opentrons-auth-server.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ot_check_remote_access_allowed
+ExecStart=/usr/bin/opentrons_check_remote_access_allowed
 
 
 [Install]

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
@@ -6,9 +6,6 @@ After=opentrons-auth-server.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Environment=PYTHONPATH=/opt/opentrons-auth-server
-Environment=CHECK_REMOTE_ACCESS_auth_server_uds=/run/opentrons-auth-server.sock
-Environment=CHECK_REMOTE_ACCESS_override_file=/etc/.allow-remote-access
 ExecStart=/usr/bin/ot_check_remote_access_allowed
 
 

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
@@ -10,4 +10,4 @@ ExecStart=/usr/bin/opentrons_check_remote_access_allowed
 
 [Install]
 RequiredBy=dropbear@.service
-RequiredBy=jupyter.service
+RequiredBy=jupyter-notebook.service

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Opentrons remote-access-allowed trigger service
+Requires=opentrons-auth-server.service
+After=opentrons-auth-server.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=PYTHONPATH=/opt/opentrons-auth-server
+Environment=CHECK_REMOTE_ACCESS_auth_server_uds=/run/opentrons-auth-server.sock
+Environment=CHECK_REMOTE_ACCESS_override_file=/etc/.allow-remote-access
+ExecStart=/usr/bin/ot_check_remote_access_allowed
+
+
+[Install]
+RequiredBy=dropbear@.service
+RequiredBy=jupyter.service

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-remote-access-allowed.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Opentrons remote-access-allowed trigger service
-Requires=opentrons-auth-server.service
 After=opentrons-auth-server.service
 
 [Service]

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
@@ -17,7 +17,11 @@ inherit systemd get_ot_package_version
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "opentrons-auth-server.service"
 FILESEXTRAPATHS:prepend = "${THISDIR}/files:"
-SRC_URI:append = " file://opentrons-auth-server.service"
+SRC_URI:append = "\
+    file://opentrons-auth-server.service \
+    file://check_remote_access_allowed \
+    file://opentrons-remote-access-allowed.service \
+    "
 
 OPENTRONS_APP_BUNDLE_PROJECT_ROOT = "${S}/auth-server"
 OPENTRONS_APP_BUNDLE_DIR = "/opt/opentrons-auth-server"
@@ -38,12 +42,18 @@ do_install:append () {
     install -d ${D}/${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-auth-server.service ${D}/${systemd_system_unitdir}/opentrons-auth-server.service
 
+    install -m 0644 ${WORKDIR}/opentrons-remote-access-allowed.service ${D}/${systemd_system_unitdir}/opentrons-remote-access-allowed.service
+
+    install -m 0744 ${WORKDIR}/check_remote_access_allowed ${D}/${bindir}/check_remote_access_allowed
+
     # remove pycaches
     rm -rf ${D}${OPENTRONS_APP_BUNDLE_DIR}/**/__pycache__
 }
 
 FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-auth-server.service.d \
                        ${systemd_system_unitdir}/opentrons-auth-server.service.d/auth-server-version.conf \
+                       ${systemd_system_unitdir}/opentrons-remote-access-allowed.service \
+                       ${bindir}/check_remote_access_allowed \
                        "
 
 RDEPENDS:${PN} += " python3-pyjwt nginx python3-systemd argon2 python3-argon2-cffi "

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
@@ -44,7 +44,7 @@ do_install:append () {
 
     install -m 0644 ${WORKDIR}/opentrons-remote-access-allowed.service ${D}/${systemd_system_unitdir}/opentrons-remote-access-allowed.service
 
-    install -m 0744 ${WORKDIR}/check_remote_access_allowed ${D}/${bindir}/check_remote_access_allowed
+    install -m 0744 ${WORKDIR}/check_remote_access_allowed ${D}/${bindir}/opentrons_check_remote_access_allowed
 
     # remove pycaches
     rm -rf ${D}${OPENTRONS_APP_BUNDLE_DIR}/**/__pycache__
@@ -53,7 +53,7 @@ do_install:append () {
 FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-auth-server.service.d \
                        ${systemd_system_unitdir}/opentrons-auth-server.service.d/auth-server-version.conf \
                        ${systemd_system_unitdir}/opentrons-remote-access-allowed.service \
-                       ${bindir}/check_remote_access_allowed \
+                       ${bindir}/opentrons_check_remote_access_allowed \
                        "
 
 RDEPENDS:${PN} += " python3-pyjwt nginx python3-systemd argon2 python3-argon2-cffi "

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
@@ -41,10 +41,10 @@ do_install:append () {
 
     install -d ${D}/${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/opentrons-auth-server.service ${D}/${systemd_system_unitdir}/opentrons-auth-server.service
-
     install -m 0644 ${WORKDIR}/opentrons-remote-access-allowed.service ${D}/${systemd_system_unitdir}/opentrons-remote-access-allowed.service
 
-    install -m 0744 ${WORKDIR}/check_remote_access_allowed ${D}/${bindir}/opentrons_check_remote_access_allowed
+    install -d ${D}${bindir}
+    install -m 0744 ${WORKDIR}/check_remote_access_allowed ${D}${bindir}/opentrons_check_remote_access_allowed
 
     # remove pycaches
     rm -rf ${D}${OPENTRONS_APP_BUNDLE_DIR}/**/__pycache__

--- a/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-jupyter-notebook/files/jupyter-notebook.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Jupyter notebook server
+Requires=opentrons-remote-access-allowed.service
+After=opentrons-remote-access-allowed.service
 
 [Service]
 Type=simple

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app-devtools.service
@@ -3,6 +3,8 @@ Requires=opentrons-robot-app.service
 After=opentrons-robot-app.service
 Requires=opentrons-robot-app-devtools.socket
 After=opentrons-robot-app-devtools.socket
+Requires=opentrons-remote-access-allowed.service
+After=opentrons-remote-access-allowed.service
 
 [Service]
 ExecStart=/lib/systemd/systemd-socket-proxyd 127.0.0.1:9222


### PR DESCRIPTION
Add a systemd unit that will succeed if remote access is allowed. That means
- Auth server is up and CRS is disabled
- Auth server is up and /etc/.allow-remote-access exists

That last file is on the read-only file system in a directory owned by root; you can only make it through a serial cable and only by remounting the rootfs, and then regardless of what you do it'll be blown away by a software update before the system is accessible again.

We can then set `After=` and `Requires=` dependencies on it in any unit that we deem requires remote access, and that unit won't start if this unit fails. For Jupyter, that means until reboot (or until the jupyter-notebook service is retriggered, anyway) but if you add or remove the file, or add or remove CRS, that means that ssh and devtools will immediately start/stop accepting new connections. Any active connections will not be terminated.

Closes EXEC-2549
Closes EXEC-2758
Closes EXEC-2550

## to come out of draft
- [x] copy these files on a robot to test
- [x] get a successful build
- [x] get that build on a robot to test