### PR TITLE
layers/meta-opentrons: protocol access

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server-permissions.conf
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server-permissions.conf
@@ -15,5 +15,6 @@ z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols/*/*.*          0640
 z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols/*/*.*    0640  root        ot-protocol
 # userspace permissions
 Z       /data/                                                              -     root        ot-protocol
+Z       /data/logs/*.*                                                      0666  -           -
 d       /var/user-packages                                                  0775  ot-protocol ot-protocol
 Z       /var/user-packages                                                  -     ot-protocol ot-protocol

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server-permissions.conf
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server-permissions.conf
@@ -15,5 +15,5 @@ z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols/*/*.*          0640
 z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols/*/*.*    0640  root        ot-protocol
 # userspace permissions
 Z       /data/                                                              -     root        ot-protocol
-d       /var/user-packages                                                  0775  root        ot-protocol
-Z       /var/user-packages                                                  -     root        ot-protocol
+d       /var/user-packages                                                  0775  ot-protocol ot-protocol
+Z       /var/user-packages                                                  -     ot-protocol ot-protocol

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server-permissions.conf
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server-permissions.conf
@@ -1,16 +1,19 @@
 # Opentrons-robot-server directory user permissions, only for SCHEMA>=17
 # Type  Path                                                                Mode  User  Group
-z       /var/lib/opentrons-robot-server                                     0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/1[7-9]                              0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[2-9][0-9]                          0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*                    0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/1[7-9]/protocols                    0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols                0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols          0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/1[7-9]/protocols/*                  0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols/*              0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols/*        0750  root  ot-protocol
-z       /var/lib/opentrons-robot-server/1[7-9]/protocols/*/*.*              0640  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols/*/*.*          0640  root  ot-protocol
-z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols/*/*.*    0640  root  ot-protocol
-z       /data/logs/sensor.log                                               0666  root  ot-protocol
+z       /var/lib/opentrons-robot-server                                     0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/1[7-9]                              0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[2-9][0-9]                          0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*                    0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/1[7-9]/protocols                    0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols                0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols          0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/1[7-9]/protocols/*                  0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols/*              0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols/*        0750  root        ot-protocol
+z       /var/lib/opentrons-robot-server/1[7-9]/protocols/*/*.*              0640  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[2-9][0-9]/protocols/*/*.*          0640  root        ot-protocol
+z       /var/lib/opentrons-robot-server/[1-9][0-9][0-9]*/protocols/*/*.*    0640  root        ot-protocol
+# userspace permissions
+Z       /data/                                                              -     root        ot-protocol
+d       /var/user-packages                                                  0775  root        ot-protocol
+Z       /var/user-packages                                                  -     root        ot-protocol

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/opentrons-robot-server.bb
@@ -19,7 +19,7 @@ USERADD_DEPENDS = "systemd"
 USERADD_PARAM:${PN} = "--system --home /run/ot-protocol \
                        --no-create-home --shell /bin/false \
                        --user-group \
-                       -G adm,systemd-journal \
+                       -G adm,systemd-journal,disk \
                        ot-protocol"
 
 SYSTEMD_AUTO_ENABLE = "enable"


### PR DESCRIPTION
Protocols need to be able to install python libraries to the user-packages tree, modify data in /data, and access USB drives. this should let them do that. Disk access is done by adding the `disk` supplemental group, which our automount script puts fat and vfat drives into (linux fses just have their normal permissions, so you need to make things world-writable and readable there, not that anybody puts ext4 on a thumb drive ever); filesystem access is done with tmpfiles. This lets these things get written by ot-protocol, which you can verify with a command like `su -l -c 'pip3 install --force-reinstall --no-deps colorak' -s /bin/sh ot-protocol` and then check that things show up in `/var/user-packages/usr/lib/python3.12/site-packages`, and not in `/var/user-packages/.local`, and doesn't fail.

Closes EXEC-2920
Closes EXEC-2866
Closes EXEC-2918