### PR TITLE
layers/meta-opentrons: add a way to disable crs

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-disable-crs
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/files/opentrons-disable-crs
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Disable compliance-ready software.
+
+die() {
+    echo "Failed: ${1}"
+    exit 1
+}
+
+echo -n 'Password: '
+read -rs password
+
+serial=$(cat /var/serial)
+
+[ "${password}" = "${serial}-0000" ] || die "Incorrect password"
+
+echo "Exiting CRS"
+rm -rf /var/lib/opentrons-auth-server
+echo "Rebooting"
+reboot

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
@@ -59,7 +59,7 @@ FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-auth-server.service.d 
                        ${bindir}/opentrons_disable_crs \
                        "
 
-RDEPENDS:${PN} += " python3-pyjwt nginx python3-systemd argon2 python3-argon2-cffi "
+RDEPENDS:${PN} += " python3-pyjwt nginx python3-systemd argon2 python3-argon2-cffi bash "
 
 DEPENDS += " cargo-native "
 

--- a/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
+++ b/layers/meta-opentrons/recipes-robot/opentrons-auth-server/opentrons-auth-server.bb
@@ -21,6 +21,7 @@ SRC_URI:append = "\
     file://opentrons-auth-server.service \
     file://check_remote_access_allowed \
     file://opentrons-remote-access-allowed.service \
+    file://opentrons-disable-crs \
     "
 
 OPENTRONS_APP_BUNDLE_PROJECT_ROOT = "${S}/auth-server"
@@ -45,6 +46,7 @@ do_install:append () {
 
     install -d ${D}${bindir}
     install -m 0744 ${WORKDIR}/check_remote_access_allowed ${D}${bindir}/opentrons_check_remote_access_allowed
+    install -m 0700 ${WORKDIR}/opentrons-disable-crs ${D}${bindir}/opentrons_disable_crs
 
     # remove pycaches
     rm -rf ${D}${OPENTRONS_APP_BUNDLE_DIR}/**/__pycache__
@@ -54,6 +56,7 @@ FILES:${PN}:append = " ${systemd_system_unitdir/opentrons-auth-server.service.d 
                        ${systemd_system_unitdir}/opentrons-auth-server.service.d/auth-server-version.conf \
                        ${systemd_system_unitdir}/opentrons-remote-access-allowed.service \
                        ${bindir}/opentrons_check_remote_access_allowed \
+                       ${bindir}/opentrons_disable_crs \
                        "
 
 RDEPENDS:${PN} += " python3-pyjwt nginx python3-systemd argon2 python3-argon2-cffi "


### PR DESCRIPTION
It's a script! opentrons_disable_crs. You need the same password you do to enable it, and it just blows away the auth server state dir and restarts.

Closes EXEC-2176