### PR TITLE
layers/meta-opentrons: Ensure pyro systemd services restart as group

### DIFF
--- a/layers/meta-opentrons/recipes-robot/opentrons-pyro-nameserver/files/opentrons-pyro-nameserver.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-pyro-nameserver/files/opentrons-pyro-nameserver.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=System service for the Python Remote Objects Nameserver
 Before=opentrons-robot-server.service
+PartOf=opentrons-hardware-api.service opentrons-robot-server.service
 
 [Service]
 # Begin the Opentrons Pyro5 Nameserver

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-hardware-api.service
@@ -5,6 +5,7 @@ After=opentrons-ot3-canbus.service
 Wants=opentrons-pyro-nameserver.service
 After=opentrons-pyro-nameserver.service
 Before=opentrons-robot-server.service
+PartOf=opentrons-pyro-nameserver.service opentrons-robot-server.service
 
 [Service]
 # Ensure the subprocess is enabled to continue

--- a/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
+++ b/layers/meta-opentrons/recipes-robot/opentrons-robot-server/files/opentrons-robot-server.service
@@ -12,6 +12,7 @@ After=opentrons-pyro-nameserver.service
 Wants=opentrons-hardware-api.service
 Wants=opentrons-audit-server.service
 After=opentrons-audit-server.service
+PartOf=opentrons-pyro-nameserver.service opentrons-hardware-api.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Covers: EXEC-2677, RQA-5790, RQA-5789

This PR updates the `opentrons-pyro-nameserver`, `opentrons-robot-server` and `opentrons-hardware-api` services to ensure that if one of them restarts all of them restart. This should solve our pain points of something like the robot server losing it's hardware api resource.

In the future we may want to make these services intelligently re-find eachother, instead of restarting when one goes down.